### PR TITLE
Add PS module for safe randomness initialization

### DIFF
--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod apt;
 pub mod fs;
 pub mod gspgpu;
 pub mod hid;
+pub mod ps;
 pub mod soc;
 pub mod sslc;
 

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -1,0 +1,21 @@
+#[non_exhaustive]
+pub struct Ps;
+
+impl Ps {
+    pub fn init() -> crate::Result<Self> {
+        let r = unsafe { ctru_sys::psInit() };
+        if r < 0 {
+            Err(r.into())
+        } else {
+            Ok(Self)
+        }
+    }
+}
+
+impl Drop for Ps {
+    fn drop(&mut self) {
+        unsafe {
+            ctru_sys::psExit();
+        }
+    }
+}

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -1,7 +1,15 @@
+//! Process Services (PS) module. This is used for miscellaneous utility tasks, but
+//! is particularly important because it is used to generate random data, which
+//! is required for common things like [`HashMap`](std::collections::HashMap).
+//! See also <https://www.3dbrew.org/wiki/Process_Services>
+
+/// PS handle. This must not be dropped in order for random generation
+/// to work (in most cases, the lifetime of an application).
 #[non_exhaustive]
 pub struct Ps;
 
 impl Ps {
+    /// Initialize the PS module.
     pub fn init() -> crate::Result<Self> {
         let r = unsafe { ctru_sys::psInit() };
         if r < 0 {


### PR DESCRIPTION
Ref #38 

If we decide we want to do a `#[ctru::main]`, I think it would use this and probably also some other stuff that's current in `ctru::init`. Figured I'd put up the PR for this part at least.