### PR TITLE
Use custom test framework to `cargo test` !

### DIFF
--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -1,5 +1,8 @@
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
+#![feature(test)]
+#![feature(custom_test_frameworks)]
+#![test_runner(test_runner::test_runner)]
 
 /// Call this somewhere to force Rust to link some required crates
 /// This is also a setup for some crate integration only available at runtime
@@ -60,6 +63,9 @@ cfg_if::cfg_if! {
         }
     }
 }
+
+#[cfg(test)]
+mod test_runner;
 
 pub use crate::error::{Error, Result};
 

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -2,7 +2,7 @@
 #![crate_name = "ctru"]
 #![feature(test)]
 #![feature(custom_test_frameworks)]
-#![test_runner(test_runner::test_runner)]
+#![test_runner(test_runner::run)]
 
 /// Call this somewhere to force Rust to link some required crates
 /// This is also a setup for some crate integration only available at runtime

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -27,3 +27,48 @@ impl Drop for Ps {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn construct_hash_map() {
+        let _ps = Ps::init().unwrap();
+
+        let mut m: HashMap<i32, String> = HashMap::from_iter([
+            (1_i32, String::from("123")),
+            (2, String::from("2")),
+            (6, String::from("six")),
+        ]);
+
+        println!("{:?}", m);
+
+        m.remove(&2);
+        m.insert(5, "ok".into());
+
+        println!("{:#?}", m);
+    }
+
+    #[test]
+    #[should_panic]
+    fn construct_hash_map_no_rand() {
+        // Without initializing PS, we can't use `libc::getrandom` and constructing
+        // a HashMap panics at runtime.
+
+        let mut m: HashMap<i32, String> = HashMap::from_iter([
+            (1_i32, String::from("123")),
+            (2, String::from("2")),
+            (6, String::from("six")),
+        ]);
+
+        println!("{:?}", m);
+
+        m.remove(&2);
+        m.insert(5, "ok".into());
+
+        println!("{:#?}", m);
+    }
+}

--- a/ctru-rs/src/test_runner.rs
+++ b/ctru-rs/src/test_runner.rs
@@ -1,0 +1,46 @@
+//! Custom test runner for building/running unit tests on the 3DS.
+
+extern crate test;
+
+use test::TestFn;
+
+use crate::console::Console;
+use crate::gfx::Gfx;
+use crate::services::hid::{Hid, KeyPad};
+
+/// A custom runner to be used with `#[test_runner]`. This simple implementation
+/// runs all tests in series, "failing" on the first one to panic (really, the
+/// panic is just treated the same as any normal application panic).
+pub(crate) fn test_runner(test_cases: &[&test::TestDescAndFn]) {
+    crate::init();
+
+    let gfx = Gfx::default();
+    let hid = Hid::init().expect("Couldn't obtain HID controller");
+    let _console = Console::init(gfx.top_screen.borrow_mut());
+
+    // TODO: may want to use some more features of standard testing framework,
+    // like output capture, filtering, panic handling, etc.
+    // For now this is works without too much setup.
+    for test_info in test_cases {
+        if let TestFn::StaticTestFn(testfn) = test_info.testfn {
+            println!("Running test {}", test_info.desc.name);
+            testfn();
+        } else {
+            println!(
+                "unsupported test type for {}: {:?}",
+                test_info.desc.name, test_info.testfn
+            );
+        }
+    }
+
+    println!("All tests passed! Press START to exit.");
+
+    // TODO: do we need apt.main_loop() here?
+    loop {
+        hid.scan_input();
+
+        if hid.keys_down().contains(KeyPad::KEY_START) {
+            break;
+        }
+    }
+}

--- a/ctru-rs/src/test_runner.rs
+++ b/ctru-rs/src/test_runner.rs
@@ -9,15 +9,17 @@ use test::{ColorConfig, Options, OutputFormat, RunIgnored, TestDescAndFn, TestFn
 use crate::console::Console;
 use crate::gfx::Gfx;
 use crate::services::hid::{Hid, KeyPad};
+use crate::services::Apt;
 
 /// A custom runner to be used with `#[test_runner]`. This simple implementation
 /// runs all tests in series, "failing" on the first one to panic (really, the
 /// panic is just treated the same as any normal application panic).
-pub(crate) fn test_runner(tests: &[&TestDescAndFn]) {
+pub(crate) fn run(tests: &[&TestDescAndFn]) {
     crate::init();
 
     let gfx = Gfx::default();
     let hid = Hid::init().unwrap();
+    let apt = Apt::init().unwrap();
 
     let mut top_screen = gfx.top_screen.borrow_mut();
     top_screen.set_wide_mode(true);
@@ -38,18 +40,17 @@ pub(crate) fn test_runner(tests: &[&TestDescAndFn]) {
         exclude_should_panic: false,
         run_ignored: RunIgnored::No,
         run_tests: true,
-        // Benchmarks are not supported
+        // Don't run benchmarks. We may want to create a separate runner for them in the future
         bench_benchmarks: false,
         logfile: None,
         nocapture: false,
         // TODO: color doesn't work because of TERM/TERMINFO.
         // With RomFS we might be able to fake this out nicely...
-        color: ColorConfig::AlwaysColor,
+        color: ColorConfig::AutoColor,
         format: OutputFormat::Pretty,
         shuffle: false,
         shuffle_seed: None,
-        // tweak values? This seems to work out of the box
-        test_threads: Some(3),
+        test_threads: None,
         skip: Vec::new(),
         time_options: None,
         options: Options::new(),
@@ -61,19 +62,19 @@ pub(crate) fn test_runner(tests: &[&TestDescAndFn]) {
     // Make sure the user can actually see the results before we exit
     println!("Press START to exit.");
 
-    gfx.flush_buffers();
-    gfx.swap_buffers();
+    while apt.main_loop() {
+        gfx.flush_buffers();
+        gfx.swap_buffers();
+        gfx.wait_for_vblank();
 
-    loop {
         hid.scan_input();
-
         if hid.keys_down().contains(KeyPad::KEY_START) {
             break;
         }
     }
 }
 
-/// Adapted from [`test::test_main_static`], along with [`make_owned_test`].
+/// Adapted from [`test::test_main_static`] and [`test::make_owned_test`].
 fn run_static_tests(opts: &TestOpts, tests: &[&TestDescAndFn]) -> io::Result<bool> {
     let tests = tests.iter().map(make_owned_test).collect();
     test::run_tests_console(opts, tests)
@@ -98,8 +99,7 @@ fn make_owned_test(test: &&TestDescAndFn) -> TestDescAndFn {
 }
 
 /// The following functions are stubs needed to link the test library,
-/// but do nothing because we don't actually need them for it to work (hopefully).
-// TODO: move to linker-fix-3ds ?
+/// but do nothing because we don't actually need them for the runner to work.
 mod link_fix {
     #[no_mangle]
     extern "C" fn execvp(
@@ -111,15 +111,6 @@ mod link_fix {
 
     #[no_mangle]
     extern "C" fn pipe(_fildes: *mut libc::c_int) -> libc::c_int {
-        -1
-    }
-
-    #[no_mangle]
-    extern "C" fn pthread_sigmask(
-        _how: ::libc::c_int,
-        _set: *const libc::sigset_t,
-        _oldset: *mut libc::sigset_t,
-    ) -> ::libc::c_int {
         -1
     }
 

--- a/ctru-rs/src/test_runner.rs
+++ b/ctru-rs/src/test_runner.rs
@@ -2,7 +2,9 @@
 
 extern crate test;
 
-use test::TestFn;
+use std::io;
+
+use test::{ColorConfig, Options, OutputFormat, RunIgnored, TestDescAndFn, TestFn, TestOpts};
 
 use crate::console::Console;
 use crate::gfx::Gfx;
@@ -11,36 +13,123 @@ use crate::services::hid::{Hid, KeyPad};
 /// A custom runner to be used with `#[test_runner]`. This simple implementation
 /// runs all tests in series, "failing" on the first one to panic (really, the
 /// panic is just treated the same as any normal application panic).
-pub(crate) fn test_runner(test_cases: &[&test::TestDescAndFn]) {
+pub(crate) fn test_runner(tests: &[&TestDescAndFn]) {
     crate::init();
 
     let gfx = Gfx::default();
-    let hid = Hid::init().expect("Couldn't obtain HID controller");
-    let _console = Console::init(gfx.top_screen.borrow_mut());
+    let hid = Hid::init().unwrap();
 
-    // TODO: may want to use some more features of standard testing framework,
-    // like output capture, filtering, panic handling, etc.
-    // For now this is works without too much setup.
-    for test_info in test_cases {
-        if let TestFn::StaticTestFn(testfn) = test_info.testfn {
-            println!("Running test {}", test_info.desc.name);
-            testfn();
-        } else {
-            println!(
-                "unsupported test type for {}: {:?}",
-                test_info.desc.name, test_info.testfn
-            );
-        }
-    }
+    let mut top_screen = gfx.top_screen.borrow_mut();
+    top_screen.set_wide_mode(true);
+    let _console = Console::init(top_screen);
 
-    println!("All tests passed! Press START to exit.");
+    // Start printing from the top left
+    print!("\x1b[1;1H");
 
-    // TODO: do we need apt.main_loop() here?
+    // TODO: it would be nice to have a way of specifying argv to make these
+    // configurable at runtime, but I can't figure out how to do it easily,
+    //  so for now, just hardcode everything.
+    let opts = TestOpts {
+        list: false,
+        filters: Vec::new(),
+        filter_exact: false,
+        // Forking is not supported
+        force_run_in_process: true,
+        exclude_should_panic: false,
+        run_ignored: RunIgnored::No,
+        run_tests: true,
+        // Benchmarks are not supported
+        bench_benchmarks: false,
+        logfile: None,
+        nocapture: false,
+        // TODO: color doesn't work because of TERM/TERMINFO.
+        // With RomFS we might be able to fake this out nicely...
+        color: ColorConfig::AlwaysColor,
+        format: OutputFormat::Pretty,
+        shuffle: false,
+        shuffle_seed: None,
+        // tweak values? This seems to work out of the box
+        test_threads: Some(3),
+        skip: Vec::new(),
+        time_options: None,
+        options: Options::new(),
+    };
+
+    // Use the default test implementation with our hardcoded options
+    let _success = run_static_tests(&opts, tests).unwrap();
+
+    // Make sure the user can actually see the results before we exit
+    println!("Press START to exit.");
+
+    gfx.flush_buffers();
+    gfx.swap_buffers();
+
     loop {
         hid.scan_input();
 
         if hid.keys_down().contains(KeyPad::KEY_START) {
             break;
         }
+    }
+}
+
+/// Adapted from [`test::test_main_static`], along with [`make_owned_test`].
+fn run_static_tests(opts: &TestOpts, tests: &[&TestDescAndFn]) -> io::Result<bool> {
+    let tests = tests.iter().map(make_owned_test).collect();
+    test::run_tests_console(opts, tests)
+}
+
+/// Clones static values for putting into a dynamic vector, which test_main()
+/// needs to hand out ownership of tests to parallel test runners.
+///
+/// This will panic when fed any dynamic tests, because they cannot be cloned.
+fn make_owned_test(test: &&TestDescAndFn) -> TestDescAndFn {
+    match test.testfn {
+        TestFn::StaticTestFn(f) => TestDescAndFn {
+            testfn: TestFn::StaticTestFn(f),
+            desc: test.desc.clone(),
+        },
+        TestFn::StaticBenchFn(f) => TestDescAndFn {
+            testfn: TestFn::StaticBenchFn(f),
+            desc: test.desc.clone(),
+        },
+        _ => panic!("non-static tests passed to test::test_main_static"),
+    }
+}
+
+/// The following functions are stubs needed to link the test library,
+/// but do nothing because we don't actually need them for it to work (hopefully).
+// TODO: move to linker-fix-3ds ?
+mod link_fix {
+    #[no_mangle]
+    extern "C" fn execvp(
+        _argc: *const libc::c_char,
+        _argv: *mut *const libc::c_char,
+    ) -> libc::c_int {
+        -1
+    }
+
+    #[no_mangle]
+    extern "C" fn pipe(_fildes: *mut libc::c_int) -> libc::c_int {
+        -1
+    }
+
+    #[no_mangle]
+    extern "C" fn pthread_sigmask(
+        _how: ::libc::c_int,
+        _set: *const libc::sigset_t,
+        _oldset: *mut libc::sigset_t,
+    ) -> ::libc::c_int {
+        -1
+    }
+
+    #[no_mangle]
+    extern "C" fn sigemptyset(_arg1: *mut libc::sigset_t) -> ::libc::c_int {
+        -1
+    }
+
+    #[no_mangle]
+    extern "C" fn sysconf(_name: libc::c_int) -> libc::c_long {
+        -1
     }
 }

--- a/ctru-rs/src/test_runner.rs
+++ b/ctru-rs/src/test_runner.rs
@@ -25,9 +25,6 @@ pub(crate) fn run(tests: &[&TestDescAndFn]) {
     top_screen.set_wide_mode(true);
     let _console = Console::init(top_screen);
 
-    // Start printing from the top left
-    print!("\x1b[1;1H");
-
     // TODO: it would be nice to have a way of specifying argv to make these
     // configurable at runtime, but I can't figure out how to do it easily,
     //  so for now, just hardcode everything.


### PR DESCRIPTION
Closes #25 , I think...

This basically plugs in the default test framework with hardcoded options
You can test it manually like this until cargo-3ds has support (.elf filename with hash may be different):

```sh
smdhtool --create ctru-rs-test "test ctru-s" "no author" /opt/devkitpro/libctru/default_icon.png target/armv6k-nintendo-3ds/debug/deps/ctru.smdh

cargo 3ds test  --no-run --lib --package ctru-rs && \
    3dsxtool --smdh=target/armv6k-nintendo-3ds/debug/deps/ctru.smdh \
        target/armv6k-nintendo-3ds/debug/deps/ctru-2d17fcbfba13d8a9.elf \
        target/armv6k-nintendo-3ds/debug/deps/ctru-test.3dsx && \
    3dslink  target/armv6k-nintendo-3ds/debug/deps/ctru-test.3dsx
```

For now I included the `Ps` changes since they seemed easy to plug into this, but I can take them out / wait for that to merge:

- [x] #39 

Things that seem to work correctly:

* Threading
* Output capture

Things that don't / won't work, as far as I know:

* Subprocessing
* Color output (we may be able to work around this)

Things I haven't tested

* Shuffling tests
* Benchmark tests
* Filtering / ignoring tests
* Timeouts
* Streamed output while running (probably would require some changes to flush the gfx while the tests are running)
* Logfile

# Screenshots
Failed Test
![image](https://user-images.githubusercontent.com/55318903/152373385-c8227814-e871-438a-988c-930488e2e74d.png)

All Passed
![image](https://user-images.githubusercontent.com/55318903/152373743-31fe81e1-6df8-4f9a-91d2-f7e12e104845.png)
