### PR TITLE
Write a console that does not flush gfx buffers

### DIFF
--- a/ctru-rs/src/console/non_flushing.rs
+++ b/ctru-rs/src/console/non_flushing.rs
@@ -1,0 +1,90 @@
+//! This is a bit of a hack, but allows us to reuse most of the libctru console
+//! implementation without writing one from scratch. This lets the user control
+//! when the console characters are flushed to the screen, which can help prevent
+//! deadlocks while using the console and graphics simultaneously.
+
+use ctru_sys::PrintConsole;
+
+/// Print a character to the console, without flushing the graphics buffers.
+/// Falls back to the default implementation for any characters other than
+/// `\n` or `\r`, which are the only ones that normally result in a flush.
+pub extern "C" fn print_char(console: *mut libc::c_void, c: i32) -> bool {
+    let console = unsafe { &mut *(console.cast::<PrintConsole>()) };
+
+    let ret = match c {
+        // '\r'
+        10 => {
+            new_row(console);
+            console.cursorX = 0;
+            true
+        }
+        // '\n'
+        13 => {
+            console.cursorX = 0;
+            true
+        }
+        _ => false, // use default console printer
+    };
+
+    if console.cursorX >= console.windowWidth {
+        console.cursorX = 0;
+        new_row(console);
+        true
+    } else {
+        ret
+    }
+}
+
+/// Direct port of
+/// <https://github.com/devkitPro/libctru/blob/master/libctru/source/console.c#L724>
+fn new_row(console: &mut PrintConsole) {
+    console.cursorY += 1;
+
+    if console.cursorY >= console.windowHeight {
+        console.cursorY -= 1;
+        let idx = (console.windowX * 8 * 240) + (239 - (console.windowY * 8));
+
+        unsafe {
+            let mut dst: *mut u16 = console.frameBuffer.offset(idx as _);
+            let mut src: *mut u16 = dst.offset(-8);
+
+            for _ in 0..console.windowWidth * 8 {
+                let mut from: *mut u32 = (src as i32 & !3) as _;
+                let mut to: *mut u32 = (dst as i32 & !3) as _;
+                for _ in 0..(((console.windowHeight - 1) * 8) / 2) {
+                    *to = *from;
+                    to = to.offset(-1);
+                    from = from.offset(-1);
+                }
+
+                dst = dst.offset(240);
+                src = src.offset(240);
+            }
+        }
+
+        clear_line(console);
+    }
+}
+
+// HACK: this is technically an implementation detail of libctru's console,
+//  but it has a that we can link to. We use this so we don't need to re-implement
+// the entire call stack down from clear_line just to print some spaces characters.
+extern "C" {
+    fn consolePrintChar(c: i32);
+}
+
+/// Direct port of `consoleClearLine('2')`, minus the flush at the end.
+/// <https://github.com/devkitPro/libctru/blob/master/libctru/source/console.c#L231>
+fn clear_line(console: &mut PrintConsole) {
+    let col_tmp = console.cursorX;
+
+    console.cursorX = 0;
+
+    for _ in 0..console.windowWidth {
+        unsafe {
+            consolePrintChar(b' ' as i32);
+        }
+    }
+
+    console.cursorX = col_tmp;
+}


### PR DESCRIPTION
@Meziu @AzureMarker 

The default libctru console calls `gfxFlushBuffers` whenever it prints a `\n` or `\r` character, which is normally useful since its output will be visible immediately.

However, I have a use case where I'd like to print concurrently from multiple threads, and manage flushing of the graphics buffer myself at the end of the frame. I noticed that the `gfxFlushBuffers` seemed to cause a deadlock when run concurrently from multiple threads – perhaps a bug in the underlying implementation?

In any case, this PR hacks together a variation on `Console` that works basically the same as the default one, but does not flush the buffers. Even without fully understanding the deadlock issue I mentioned, I think this could be useful as most programs should probably only flush once per frame anyway: https://libctru.devkitpro.org/gfx_8h.html#aea1808bd74fe0c00f9794e455fc8499b
I'm hoping this will make the console usable as a debug tool on one screen while rendering / doing other stuff with the other one.

The implementation does feel a bit hacky, though, so if you have suggestions or think we shouldn't merge this, please let me know. I thought this seemed a bit easier than writing a full-blown console from scratch, anyway.