### PR TITLE
Increase default stack size to 2MB with opt-out available

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -32,8 +32,9 @@ tokio = { version = "1.16", features = ["rt", "time", "sync", "macros"] }
 cfg-if = "1.0.0"
 
 [features]
-default = ["romfs"]
+default = ["romfs", "big-stack"]
 romfs = []
+big-stack = []
 
 [package.metadata.cargo-3ds]
 romfs_dir = "examples/romfs"

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -10,6 +10,10 @@ extern "C" fn services_deinit() {
     }
 }
 
+#[no_mangle]
+#[cfg(feature = "big-stack")]
+static __stacksize__: usize = 2 * 1024 * 1024; // 2MB
+
 /// Call this somewhere to force Rust to link some required crates
 /// This is also a setup for some crate integration only available at runtime
 ///


### PR DESCRIPTION
Fix / workaround for issue seen in #56 

Add a Cargo feature to allow users to set the stack size if desired, but
default to 2MB to handle more use cases.

@Meziu @AzureMarker what do you think of this approach? Open to alternate naming suggestions on the cargo feature as well, I don't love `big-stack` but wanted to post this as a starting point for discussion.

Another approach I considered was exporting a macro like 
```rs
ctru::stack_size!(64 * 1024);
```
But it felt a bit clunky and would require _every_ user to set this if their program had large enough stacks. I would imagine that custom stack size is a pretty advanced use case (assuming we pick a good default) so I think it should still be possible for users to opt-out of the default, but I'm not sure of another way besides a Cargo feature.