### PR TITLE
Add 3dslink redirection to Soc service

### DIFF
--- a/ctru-rs/examples/output-3dslink.rs
+++ b/ctru-rs/examples/output-3dslink.rs
@@ -1,0 +1,35 @@
+use ctru::gfx::Gfx;
+use ctru::services::apt::Apt;
+use ctru::services::hid::{Hid, KeyPad};
+use ctru::services::soc::Soc;
+
+fn main() {
+    ctru::init();
+    let gfx = Gfx::init().expect("Couldn't obtain GFX controller");
+    let hid = Hid::init().expect("Couldn't obtain HID controller");
+    let apt = Apt::init().expect("Couldn't obtain APT controller");
+
+    let mut soc = Soc::init().expect("Couldn't obtain SOC controller");
+
+    soc.redirect_to_3dslink(true, true)
+        .expect("unable to redirect stdout/err to 3dslink server");
+
+    println!("Hello 3dslink!");
+    eprintln!("Press Start on the device to disconnect and exit.");
+
+    // Main loop
+    while apt.main_loop() {
+        //Scan all the inputs. This should be done once for each frame
+        hid.scan_input();
+
+        if hid.keys_down().contains(KeyPad::KEY_START) {
+            break;
+        }
+        // Flush and swap framebuffers
+        gfx.flush_buffers();
+        gfx.swap_buffers();
+
+        //Wait for VBlank
+        gfx.wait_for_vblank();
+    }
+}

--- a/ctru-rs/examples/output-3dslink.rs
+++ b/ctru-rs/examples/output-3dslink.rs
@@ -1,3 +1,13 @@
+//! Use the `3dslink --server` option for redirecting output from the 3DS back
+//! to the device that sent the executable.
+//!
+//! For now, `cargo 3ds run` does not support this flag, so to run this example
+//! it must be sent manually, like this:
+//! ```sh
+//! cargo 3ds build --example output-3dslink
+//! 3dslink --server target/armv6k-nintendo-3ds/debug/examples/output-3dslink.3dsx
+//! ```
+
 use ctru::gfx::Gfx;
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
@@ -13,6 +23,8 @@ fn main() {
 
     soc.redirect_to_3dslink(true, true)
         .expect("unable to redirect stdout/err to 3dslink server");
+
+    print!("\x1b[2J\x1b[0;0H"); // Clear screen + move to 0,0
 
     println!("Hello 3dslink!");
     eprintln!("Press Start on the device to disconnect and exit.");

--- a/ctru-rs/examples/output-3dslink.rs
+++ b/ctru-rs/examples/output-3dslink.rs
@@ -24,8 +24,6 @@ fn main() {
     soc.redirect_to_3dslink(true, true)
         .expect("unable to redirect stdout/err to 3dslink server");
 
-    print!("\x1b[2J\x1b[0;0H"); // Clear screen + move to 0,0
-
     println!("Hello 3dslink!");
     eprintln!("Press Start on the device to disconnect and exit.");
 

--- a/ctru-rs/examples/thread-info.rs
+++ b/ctru-rs/examples/thread-info.rs
@@ -10,7 +10,7 @@ use std::os::horizon::thread::BuilderExt;
 
 fn main() {
     ctru::init();
-    let gfx = Gfx::default();
+    let gfx = Gfx::init().expect("Couldn't obtain GFX controller");
     let hid = Hid::init().expect("Couldn't obtain HID controller");
     let apt = Apt::init().expect("Couldn't obtain APT controller");
     let _console = Console::init(gfx.top_screen.borrow_mut());

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -1,4 +1,5 @@
 use std::error;
+use std::ffi::CStr;
 use std::fmt;
 
 use ctru_sys::result::{R_DESCRIPTION, R_LEVEL, R_MODULE, R_SUMMARY};
@@ -9,7 +10,27 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     Os(ctru_sys::Result),
+    Libc(String),
     ServiceAlreadyActive,
+    OutputAlreadyRedirected,
+}
+
+impl Error {
+    /// Create an [`Error`] out of the last set value in `errno`. This can be used
+    /// to get a human-readable error string from calls to `libc` functions.
+    pub(crate) fn from_errno() -> Self {
+        let error_str = unsafe {
+            let errno = ctru_sys::errno();
+            let str_ptr = libc::strerror(errno);
+
+            // Safety: strerror should always return a valid string,
+            // even if the error number is unknown
+            CStr::from_ptr(str_ptr)
+        };
+
+        // Copy out of the error string, since it may be changed by other libc calls later
+        Self::Libc(error_str.to_string_lossy().into())
+    }
 }
 
 impl From<ctru_sys::Result> for Error {
@@ -20,8 +41,8 @@ impl From<ctru_sys::Result> for Error {
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Os(err) => f
+        match self {
+            &Self::Os(err) => f
                 .debug_struct("Error")
                 .field("raw", &format_args!("{:#08X}", err))
                 .field("description", &R_DESCRIPTION(err))
@@ -29,7 +50,9 @@ impl fmt::Debug for Error {
                 .field("summary", &R_SUMMARY(err))
                 .field("level", &R_LEVEL(err))
                 .finish(),
-            Error::ServiceAlreadyActive => f.debug_tuple("ServiceAlreadyActive").finish(),
+            Self::Libc(err) => f.debug_tuple("Libc").field(err).finish(),
+            Self::ServiceAlreadyActive => f.debug_tuple("ServiceAlreadyActive").finish(),
+            Self::OutputAlreadyRedirected => f.debug_tuple("OutputAlreadyRedirected").finish(),
         }
     }
 }
@@ -39,9 +62,13 @@ impl fmt::Debug for Error {
 // https://github.com/devkitPro/libctru/blob/master/libctru/include/3ds/result.h
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Os(err) => write!(f, "libctru result code: 0x{:08X}", err),
-            Error::ServiceAlreadyActive => write!(f, "Service already active"),
+        match self {
+            &Self::Os(err) => write!(f, "libctru result code: 0x{:08X}", err),
+            Self::Libc(err) => write!(f, "{}", err),
+            Self::ServiceAlreadyActive => write!(f, "Service already active"),
+            Self::OutputAlreadyRedirected => {
+                write!(f, "output streams are already redirected to 3dslink")
+            }
         }
     }
 }

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -105,7 +105,7 @@ mod tests {
 
     #[test]
     fn soc_duplicate() {
-        // let _soc = Soc::init().unwrap();
+        let _soc = Soc::init().unwrap();
 
         assert!(matches!(Soc::init(), Err(Error::ServiceAlreadyActive)))
     }

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -10,3 +10,10 @@ mod bindings;
 
 pub use bindings::*;
 pub use result::*;
+
+/// In lieu of a proper errno function exposed by libc
+/// (<https://github.com/rust-lang/libc/issues/1995>), this will retrieve the
+/// last error set in the global reentrancy struct.
+pub unsafe fn errno() -> s32 {
+    (*__getreent())._errno
+}


### PR DESCRIPTION
@Meziu @AzureMarker 

This allows you to send stdout/stderr back to the `3dslink` invocation, which will probably be really nice for graphical applications where you need both screens, etc. We might also consider putting it in the test runner (maybe as a feature flag or CLI arg?)

I'm not 100% sure about this API, maybe it would make sense to have separate `redirect_stdout()` and `redirect_stderr()` functions instead of just the one? I also wasn't sure it should be on `Soc`, but you have to initialize `Soc` before you can use this so it seemed like a somewhat reasonable place to have it.

Next up, I would probably like to add `cargo-3ds` support for this so you could do `cargo 3ds run --server` or something like that, instead of manually invoking it like I have done here.

----

Also, I fixed a broken thread-info compilation which was a small change.