### PR TITLE
Prelude module addition

### DIFF
--- a/ctru-rs/examples/buttons.rs
+++ b/ctru-rs/examples/buttons.rs
@@ -1,7 +1,4 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
 
 fn main() {
     // Setup services

--- a/ctru-rs/examples/file-explorer.rs
+++ b/ctru-rs/examples/file-explorer.rs
@@ -2,10 +2,8 @@
 //! read the SD card.
 
 use ctru::applets::swkbd::{Button, Swkbd};
-use ctru::console::Console;
-use ctru::services::hid::KeyPad;
-use ctru::services::{Apt, Hid};
-use ctru::Gfx;
+use ctru::prelude::*;
+
 use std::fs::DirEntry;
 use std::os::horizon::fs::MetadataExt;
 use std::path::{Path, PathBuf};

--- a/ctru-rs/examples/futures-basic.rs
+++ b/ctru-rs/examples/futures-basic.rs
@@ -7,10 +7,8 @@
 
 #![feature(horizon_thread_ext)]
 
-use ctru::console::Console;
-use ctru::services::hid::KeyPad;
-use ctru::services::{Apt, Hid};
-use ctru::Gfx;
+use ctru::prelude::*;
+
 use futures::StreamExt;
 use std::os::horizon::thread::BuilderExt;
 

--- a/ctru-rs/examples/futures-tokio.rs
+++ b/ctru-rs/examples/futures-tokio.rs
@@ -1,9 +1,7 @@
 #![feature(horizon_thread_ext)]
 
-use ctru::console::Console;
-use ctru::services::hid::KeyPad;
-use ctru::services::{Apt, Hid};
-use ctru::Gfx;
+use ctru::prelude::*;
+
 use std::os::horizon::thread::BuilderExt;
 use std::time::Duration;
 

--- a/ctru-rs/examples/gfx-wide-mode.rs
+++ b/ctru-rs/examples/gfx-wide-mode.rs
@@ -1,7 +1,4 @@
-use ctru::console::Console;
-use ctru::services::hid::KeyPad;
-use ctru::services::{Apt, Hid};
-use ctru::Gfx;
+use ctru::prelude::*;
 
 fn main() {
     ctru::init();

--- a/ctru-rs/examples/graphics-bitmap.rs
+++ b/ctru-rs/examples/graphics-bitmap.rs
@@ -1,8 +1,5 @@
-use ctru::console::Console;
 use ctru::gfx::Screen as _;
-use ctru::services::hid::KeyPad;
-use ctru::services::{Apt, Hid};
-use ctru::Gfx;
+use ctru::prelude::*;
 
 /// Ferris image taken from <https://rustacean.net> and scaled down to 320x240px.
 /// To regenerate the data, you will need to install `imagemagick` and run this

--- a/ctru-rs/examples/hashmaps.rs
+++ b/ctru-rs/examples/hashmaps.rs
@@ -1,7 +1,4 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
 
 fn main() {
     // Initialize services

--- a/ctru-rs/examples/hello-both-screens.rs
+++ b/ctru-rs/examples/hello-both-screens.rs
@@ -1,7 +1,4 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
 
 fn main() {
     // Initialize services

--- a/ctru-rs/examples/hello-world.rs
+++ b/ctru-rs/examples/hello-world.rs
@@ -1,7 +1,4 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
 
 use std::io::BufWriter;
 

--- a/ctru-rs/examples/network-sockets.rs
+++ b/ctru-rs/examples/network-sockets.rs
@@ -1,8 +1,4 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
-use ctru::services::soc::Soc;
+use ctru::prelude::*;
 
 use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpListener};

--- a/ctru-rs/examples/output-3dslink.rs
+++ b/ctru-rs/examples/output-3dslink.rs
@@ -8,10 +8,7 @@
 //! 3dslink --server target/armv6k-nintendo-3ds/debug/examples/output-3dslink.3dsx
 //! ```
 
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
-use ctru::services::soc::Soc;
+use ctru::prelude::*;
 
 fn main() {
     ctru::init();

--- a/ctru-rs/examples/romfs.rs
+++ b/ctru-rs/examples/romfs.rs
@@ -1,7 +1,4 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
 
 fn main() {
     ctru::init();

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -1,8 +1,5 @@
 use ctru::applets::swkbd::{Button, Swkbd};
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
 
 fn main() {
     ctru::init();

--- a/ctru-rs/examples/system-configuration.rs
+++ b/ctru-rs/examples/system-configuration.rs
@@ -1,8 +1,5 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
+use ctru::prelude::*;
 use ctru::services::cfgu::Cfgu;
-use ctru::services::hid::{Hid, KeyPad};
 
 fn main() {
     ctru::init();

--- a/ctru-rs/examples/thread-basic.rs
+++ b/ctru-rs/examples/thread-basic.rs
@@ -1,9 +1,7 @@
 #![feature(horizon_thread_ext)]
 
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
+
 use std::os::horizon::thread::BuilderExt;
 use std::time::Duration;
 

--- a/ctru-rs/examples/thread-info.rs
+++ b/ctru-rs/examples/thread-info.rs
@@ -2,10 +2,8 @@
 
 #![feature(horizon_thread_ext)]
 
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
+
 use std::os::horizon::thread::BuilderExt;
 
 fn main() {

--- a/ctru-rs/examples/thread-locals.rs
+++ b/ctru-rs/examples/thread-locals.rs
@@ -1,9 +1,7 @@
 #![feature(horizon_thread_ext)]
 
-use ctru::console::Console;
-use ctru::services::hid::KeyPad;
-use ctru::services::{Apt, Hid};
-use ctru::Gfx;
+use ctru::prelude::*;
+
 use std::cell::RefCell;
 use std::os::horizon::thread::BuilderExt;
 

--- a/ctru-rs/examples/time-rtc.rs
+++ b/ctru-rs/examples/time-rtc.rs
@@ -1,7 +1,4 @@
-use ctru::console::Console;
-use ctru::gfx::Gfx;
-use ctru::services::apt::Apt;
-use ctru::services::hid::{Hid, KeyPad};
+use ctru::prelude::*;
 
 fn main() {
     ctru::init();

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -75,6 +75,7 @@ pub mod applets;
 pub mod console;
 pub mod error;
 pub mod gfx;
+pub mod prelude;
 pub mod services;
 pub mod srv;
 
@@ -101,6 +102,3 @@ cfg_if::cfg_if! {
 mod test_runner;
 
 pub use crate::error::{Error, Result};
-
-pub use crate::gfx::Gfx;
-pub use crate::srv::Srv;

--- a/ctru-rs/src/prelude.rs
+++ b/ctru-rs/src/prelude.rs
@@ -1,0 +1,3 @@
+pub use crate::console::Console;
+pub use crate::gfx::Gfx;
+pub use crate::services::{hid::KeyPad, soc::Soc, Apt, Hid};


### PR DESCRIPTION
Seeing the state of the many examples, and the general use of this library, I thought adding a simple `prelude` module would be  a welcomed addition to avoid many lines of repeating imports. For now I've added basic modules I would see fit in most applications (must-use like `Apt`, `Gfx` and `Hid`, plus some helpers like `Soc`, `KeyPad` and `Console`). Since the main use of any prelude module is to aid simple (usually single-file) projects, I've added only this basic functionality, but tell me if you think some other modules could be helpful.

@ian-h-chamberlain @AzureMarker 