### PR TITLE
Improve the ergonomics of calling ``ctru_sys`` functions

### DIFF
--- a/ctru-rs/examples/camera-image.rs
+++ b/ctru-rs/examples/camera-image.rs
@@ -1,9 +1,8 @@
 use ctru::console::Console;
-use ctru::gfx::{Screen, Side};
+use ctru::gfx::{Gfx, Side};
 use ctru::services::cam::{Cam, CamOutputFormat, CamShutterSoundType, CamSize, Camera};
 use ctru::services::hid::KeyPad;
 use ctru::services::{Apt, Hid};
-use ctru::Gfx;
 use std::time::Duration;
 
 const WIDTH: usize = 400;

--- a/ctru-rs/examples/camera-image.rs
+++ b/ctru-rs/examples/camera-image.rs
@@ -83,7 +83,7 @@ fn main() {
                 .expect("Failed to take picture");
         }
 
-        let img = convert_image_to_rgb8(&buf, 0, 0, WIDTH as usize, HEIGHT as usize);
+        let img = convert_image_to_rgb8(&buf, 0, 0, WIDTH, HEIGHT);
 
         unsafe {
             gfx.top_screen

--- a/ctru-rs/examples/camera-image.rs
+++ b/ctru-rs/examples/camera-image.rs
@@ -1,5 +1,5 @@
 use ctru::console::Console;
-use ctru::gfx::{Gfx, Side};
+use ctru::gfx::{Gfx, Screen, Side};
 use ctru::services::cam::{Cam, CamOutputFormat, CamShutterSoundType, CamSize, Camera};
 use ctru::services::hid::KeyPad;
 use ctru::services::{Apt, Hid};

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -15,6 +15,7 @@ impl Try for LibCtruResult {
     type Output = ();
     // This type is passed to [FromResidual::from_residual] when the LibCtruResult is an error,
     // so this type implies "this is a result than CAN'T be `Ok`" (Infallible is the same as !)
+    // The purpose of this type is to _only_ bring information about the *Error*
     type Residual = crate::Result<core::convert::Infallible>;
 
     fn from_output(_: Self::Output) -> Self {

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -22,7 +22,7 @@ impl Try for LibCtruError {
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
         match self.0 {
             0 => ControlFlow::Continue(()),
-            _ => ControlFlow::Break(Err(self.into()))
+            _ => ControlFlow::Break(Err(self.into())),
         }
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -13,6 +13,8 @@ pub(crate) struct LibCtruResult(pub i32);
 
 impl Try for LibCtruResult {
     type Output = ();
+    // This type is passed to [FromResidual::from_residual] when the LibCtruResult is an error,
+    // so this type implies "this is a result than CAN'T be `Ok`" (Infallible is the same as !)
     type Residual = crate::Result<core::convert::Infallible>;
 
     fn from_output(_: Self::Output) -> Self {
@@ -30,13 +32,9 @@ impl Try for LibCtruResult {
 
 impl FromResidual for LibCtruResult {
     fn from_residual(e: <Self as Try>::Residual) -> Self {
-        if let Some(e) = e.err() {
-            match e {
-                Error::Os(result) => Self(result),
-                _ => Self(-1),
-            }
-        } else {
-            Self(-1)
+        match e.err().unwrap() {
+            Error::Os(result) => Self(result),
+            _ => Self(-1),
         }
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -9,7 +9,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(transparent)]
-pub(crate) struct ResultCode(pub i32);
+pub(crate) struct ResultCode(pub ctru_sys::Result);
 
 impl Try for ResultCode {
     type Output = ();

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -20,9 +20,10 @@ impl Try for LibCtruError {
     }
 
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
-        match self.0 {
-            0 => ControlFlow::Continue(()),
-            _ => ControlFlow::Break(Err(self.into())),
+        if self.0 < 0 {
+            ControlFlow::Break(Err(self.into()))
+        } else {
+            ControlFlow::Continue(())
         }
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -9,9 +9,9 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[repr(transparent)]
-pub(crate) struct LibCtruError(pub i32);
+pub(crate) struct LibCtruResult(pub i32);
 
-impl Try for LibCtruError {
+impl Try for LibCtruResult {
     type Output = ();
     type Residual = crate::Result<core::convert::Infallible>;
 
@@ -28,7 +28,7 @@ impl Try for LibCtruError {
     }
 }
 
-impl FromResidual for LibCtruError {
+impl FromResidual for LibCtruResult {
     fn from_residual(e: <Self as Try>::Residual) -> Self {
         if let Some(e) = e.err() {
             match e {
@@ -74,8 +74,8 @@ impl From<ctru_sys::Result> for Error {
     }
 }
 
-impl From<LibCtruError> for Error {
-    fn from(err: LibCtruError) -> Self {
+impl From<LibCtruResult> for Error {
+    fn from(err: LibCtruResult) -> Self {
         Self::Os(err.0)
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -29,8 +29,15 @@ impl Try for LibCtruError {
 }
 
 impl FromResidual for LibCtruError {
-    fn from_residual(_: <Self as Try>::Residual) -> Self {
-        Self(1)
+    fn from_residual(e: <Self as Try>::Residual) -> Self {
+        if let Some(e) = e.err() {
+            match e {
+                Error::Os(result) => Self(result),
+                _ => Self(-1),
+            }
+        } else {
+            Self(-1)
+        }
     }
 }
 

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -7,7 +7,7 @@ use ctru_sys::result::{R_DESCRIPTION, R_LEVEL, R_MODULE, R_SUMMARY};
 
 pub type Result<T> = ::std::result::Result<T, Error>;
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(transparent)]
 pub(crate) struct LibCtruResult(pub i32);
 

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -2,6 +2,7 @@
 #![crate_name = "ctru"]
 #![feature(test)]
 #![feature(custom_test_frameworks)]
+#![feature(try_trait_v2)]
 #![test_runner(test_runner::run)]
 
 extern "C" fn services_deinit() {

--- a/ctru-rs/src/romfs.rs
+++ b/ctru-rs/src/romfs.rs
@@ -10,7 +10,7 @@
 //! romfs_dir = "romfs"
 //! ```
 
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::sync::Mutex;
@@ -31,7 +31,7 @@ impl RomFS {
             true,
             || {
                 let mount_name = CStr::from_bytes_with_nul(b"romfs\0").unwrap();
-                LibCtruResult(unsafe { ctru_sys::romfsMountSelf(mount_name.as_ptr()) })?;
+                ResultCode(unsafe { ctru_sys::romfsMountSelf(mount_name.as_ptr()) })?;
                 Ok(())
             },
             || {

--- a/ctru-rs/src/romfs.rs
+++ b/ctru-rs/src/romfs.rs
@@ -13,6 +13,7 @@
 use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::sync::Mutex;
+use crate::error::LibCtruError;
 
 use crate::services::ServiceReference;
 
@@ -30,11 +31,7 @@ impl RomFS {
             true,
             || {
                 let mount_name = CStr::from_bytes_with_nul(b"romfs\0").unwrap();
-                let r = unsafe { ctru_sys::romfsMountSelf(mount_name.as_ptr()) };
-                if r < 0 {
-                    return Err(r.into());
-                }
-
+                LibCtruError(unsafe { ctru_sys::romfsMountSelf(mount_name.as_ptr()) })?;
                 Ok(())
             },
             || {

--- a/ctru-rs/src/romfs.rs
+++ b/ctru-rs/src/romfs.rs
@@ -10,7 +10,7 @@
 //! romfs_dir = "romfs"
 //! ```
 
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::sync::Mutex;
@@ -31,7 +31,7 @@ impl RomFS {
             true,
             || {
                 let mount_name = CStr::from_bytes_with_nul(b"romfs\0").unwrap();
-                LibCtruError(unsafe { ctru_sys::romfsMountSelf(mount_name.as_ptr()) })?;
+                LibCtruResult(unsafe { ctru_sys::romfsMountSelf(mount_name.as_ptr()) })?;
                 Ok(())
             },
             || {

--- a/ctru-rs/src/romfs.rs
+++ b/ctru-rs/src/romfs.rs
@@ -10,10 +10,10 @@
 //! romfs_dir = "romfs"
 //! ```
 
+use crate::error::LibCtruError;
 use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::sync::Mutex;
-use crate::error::LibCtruError;
 
 use crate::services::ServiceReference;
 

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -1,11 +1,11 @@
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 
 pub struct Apt(());
 
 impl Apt {
     pub fn init() -> crate::Result<Apt> {
         unsafe {
-            LibCtruResult(ctru_sys::aptInit())?;
+            ResultCode(ctru_sys::aptInit())?;
             Ok(Apt(()))
         }
     }
@@ -16,7 +16,7 @@ impl Apt {
 
     pub fn set_app_cpu_time_limit(&self, percent: u32) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::APT_SetAppCpuTimeLimit(percent))?;
+            ResultCode(ctru_sys::APT_SetAppCpuTimeLimit(percent))?;
             Ok(())
         }
     }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -1,14 +1,12 @@
+use crate::error::LibCtruError;
+
 pub struct Apt(());
 
 impl Apt {
     pub fn init() -> crate::Result<Apt> {
         unsafe {
-            let r = ctru_sys::aptInit();
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(Apt(()))
-            }
+            LibCtruError(ctru_sys::aptInit())?;
+            Ok(Apt(()))
         }
     }
 
@@ -18,12 +16,8 @@ impl Apt {
 
     pub fn set_app_cpu_time_limit(&self, percent: u32) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::APT_SetAppCpuTimeLimit(percent);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::APT_SetAppCpuTimeLimit(percent))?;
+            Ok(())
         }
     }
 }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -1,11 +1,11 @@
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 
 pub struct Apt(());
 
 impl Apt {
     pub fn init() -> crate::Result<Apt> {
         unsafe {
-            LibCtruError(ctru_sys::aptInit())?;
+            LibCtruResult(ctru_sys::aptInit())?;
             Ok(Apt(()))
         }
     }
@@ -16,7 +16,7 @@ impl Apt {
 
     pub fn set_app_cpu_time_limit(&self, percent: u32) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::APT_SetAppCpuTimeLimit(percent))?;
+            LibCtruResult(ctru_sys::APT_SetAppCpuTimeLimit(percent))?;
             Ok(())
         }
     }

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -7,6 +7,7 @@ use crate::services::gspgpu::FramebufferFormat;
 use bitflags::bitflags;
 use ctru_sys::Handle;
 use std::time::Duration;
+use crate::error::LibCtruError;
 
 /// A reference-counted handle to the CAM service and the usable cameras.
 /// The service is closed when all instances of this struct fall out of scope.
@@ -267,24 +268,15 @@ impl BothOutwardCam {
         brightness_synchronization: bool,
     ) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetBrightnessSynchronization(brightness_synchronization);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetBrightnessSynchronization(brightness_synchronization))?;
+            Ok(())
         }
     }
 
     fn synchronize_vsync_timing(&self) -> crate::Result<()> {
         unsafe {
-            let r =
-                ctru_sys::CAMU_SynchronizeVsyncTiming(ctru_sys::SELECT_OUT1, ctru_sys::SELECT_OUT2);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SynchronizeVsyncTiming(ctru_sys::SELECT_OUT1, ctru_sys::SELECT_OUT2))?;
+            Ok(())
         }
     }
 }
@@ -313,12 +305,8 @@ pub trait Camera {
     fn is_busy(&self) -> crate::Result<bool> {
         unsafe {
             let mut is_busy = false;
-            let r = ctru_sys::CAMU_IsBusy(&mut is_busy, self.port_as_raw());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(is_busy)
-            }
+            LibCtruError(ctru_sys::CAMU_IsBusy(&mut is_busy, self.port_as_raw()))?;
+            Ok(is_busy)
         }
     }
 
@@ -327,12 +315,8 @@ pub trait Camera {
     fn get_transfer_bytes(&self) -> crate::Result<u32> {
         unsafe {
             let mut transfer_bytes = 0;
-            let r = ctru_sys::CAMU_GetTransferBytes(&mut transfer_bytes, self.port_as_raw());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(transfer_bytes)
-            }
+            LibCtruError(ctru_sys::CAMU_GetTransferBytes(&mut transfer_bytes, self.port_as_raw()))?;
+            Ok(transfer_bytes)
         }
     }
 
@@ -340,12 +324,8 @@ pub trait Camera {
     /// [Camera::set_trimming_params]
     fn set_trimming(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetTrimming(self.port_as_raw(), enabled);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetTrimming(self.port_as_raw(), enabled))?;
+            Ok(())
         }
     }
 
@@ -353,30 +333,22 @@ pub trait Camera {
     fn is_trimming_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut trimming = false;
-            let r = ctru_sys::CAMU_IsTrimming(&mut trimming, self.port_as_raw());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(trimming)
-            }
+            LibCtruError(ctru_sys::CAMU_IsTrimming(&mut trimming, self.port_as_raw()))?;
+            Ok(trimming)
         }
     }
 
     /// Sets trimming parameters based on coordinates specified inside a [CamTrimmingParams]
     fn set_trimming_params(&mut self, params: CamTrimmingParams) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetTrimmingParams(
+            LibCtruError(ctru_sys::CAMU_SetTrimmingParams(
                 self.port_as_raw(),
                 params.x_start,
                 params.y_start,
                 params.x_end,
                 params.y_end,
-            );
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            ))?;
+            Ok(())
         }
     }
 
@@ -387,23 +359,20 @@ pub trait Camera {
             let mut y_start = 0;
             let mut x_end = 0;
             let mut y_end = 0;
-            let r = ctru_sys::CAMU_GetTrimmingParams(
+            LibCtruError(ctru_sys::CAMU_GetTrimmingParams(
                 &mut x_start,
                 &mut y_start,
                 &mut x_end,
                 &mut y_end,
                 self.port_as_raw(),
-            );
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(CamTrimmingParams {
-                    x_start,
-                    y_start,
-                    x_end,
-                    y_end,
-                })
-            }
+            ))?;
+
+            Ok(CamTrimmingParams {
+                x_start,
+                y_start,
+                x_end,
+                y_end,
+            })
         }
     }
 
@@ -418,42 +387,30 @@ pub trait Camera {
         cam_height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetTrimmingParamsCenter(
+            LibCtruError(ctru_sys::CAMU_SetTrimmingParamsCenter(
                 self.port_as_raw(),
                 trim_width,
                 trim_height,
                 cam_width,
                 cam_height,
-            );
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            ))?;
+            Ok(())
         }
     }
 
     /// Sets the exposure level of the camera
     fn set_exposure(&mut self, exposure: i8) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetExposure(self.camera_as_raw(), exposure);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetExposure(self.camera_as_raw(), exposure))?;
+            Ok(())
         }
     }
 
     /// Sets the white balance mod of the camera based on the passed [CamWhiteBalance] argument
     fn set_white_balance(&mut self, white_balance: CamWhiteBalance) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetWhiteBalance(self.camera_as_raw(), white_balance.bits());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetWhiteBalance(self.camera_as_raw(), white_balance.bits()))?;
+            Ok(())
         }
     }
 
@@ -464,39 +421,27 @@ pub trait Camera {
         white_balance: CamWhiteBalance,
     ) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetWhiteBalanceWithoutBaseUp(
+            LibCtruError(ctru_sys::CAMU_SetWhiteBalanceWithoutBaseUp(
                 self.camera_as_raw(),
                 white_balance.bits(),
-            );
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            ))?;
+            Ok(())
         }
     }
 
     /// Sets the sharpness of the camera
     fn set_sharpness(&mut self, sharpness: i8) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetSharpness(self.camera_as_raw(), sharpness);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetSharpness(self.camera_as_raw(), sharpness))?;
+            Ok(())
         }
     }
 
     /// Sets whether auto exposure is enabled or disabled for the camera
     fn set_auto_exposure(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetAutoExposure(self.camera_as_raw(), enabled);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetAutoExposure(self.camera_as_raw(), enabled))?;
+            Ok(())
         }
     }
 
@@ -504,24 +449,16 @@ pub trait Camera {
     fn is_auto_exposure_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            let r = ctru_sys::CAMU_IsAutoExposure(&mut enabled, self.camera_as_raw());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(enabled)
-            }
+            LibCtruError(ctru_sys::CAMU_IsAutoExposure(&mut enabled, self.camera_as_raw()))?;
+            Ok(enabled)
         }
     }
 
     /// Sets whether auto white balance is enabled or disabled for the camera
     fn set_auto_white_balance(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetAutoWhiteBalance(self.camera_as_raw(), enabled);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalance(self.camera_as_raw(), enabled))?;
+            Ok(())
         }
     }
 
@@ -529,25 +466,16 @@ pub trait Camera {
     fn is_auto_white_balance_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            let r = ctru_sys::CAMU_IsAutoWhiteBalance(&mut enabled, self.camera_as_raw());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(enabled)
-            }
+            LibCtruError(ctru_sys::CAMU_IsAutoWhiteBalance(&mut enabled, self.camera_as_raw()))?;
+            Ok(enabled)
         }
     }
 
     /// Sets the flip direction of the camera's image based on the passed [CamFlip] argument
     fn flip_image(&mut self, flip: CamFlip) -> crate::Result<()> {
         unsafe {
-            let r =
-                ctru_sys::CAMU_FlipImage(self.camera_as_raw(), flip.bits(), ctru_sys::CONTEXT_A);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_FlipImage(self.camera_as_raw(), flip.bits(), ctru_sys::CONTEXT_A))?;
+            Ok(())
         }
     }
 
@@ -571,7 +499,7 @@ pub trait Camera {
         crop_1: (i16, i16),
     ) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetDetailSize(
+            LibCtruError(ctru_sys::CAMU_SetDetailSize(
                 self.camera_as_raw(),
                 width,
                 height,
@@ -580,48 +508,32 @@ pub trait Camera {
                 crop_1.0,
                 crop_1.1,
                 ctru_sys::CONTEXT_A,
-            );
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            ))?;
+            Ok(())
         }
     }
 
     /// Sets the view size of the camera based on the passed [CamSize] argument.
     fn set_view_size(&mut self, size: CamSize) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetSize(self.camera_as_raw(), size.bits(), ctru_sys::CONTEXT_A);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetSize(self.camera_as_raw(), size.bits(), ctru_sys::CONTEXT_A))?;
+            Ok(())
         }
     }
 
     /// Sets the frame rate of the camera based on the passed [CamFrameRate] argument.
     fn set_frame_rate(&mut self, frame_rate: CamFrameRate) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetFrameRate(self.camera_as_raw(), frame_rate.bits());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetFrameRate(self.camera_as_raw(), frame_rate.bits()))?;
+            Ok(())
         }
     }
 
     /// Sets the photo mode of the camera based on the passed [CamPhotoMode] argument.
     fn set_photo_mode(&mut self, photo_mode: CamPhotoMode) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetPhotoMode(self.camera_as_raw(), photo_mode.bits());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetPhotoMode(self.camera_as_raw(), photo_mode.bits()))?;
+            Ok(())
         }
     }
 
@@ -630,53 +542,36 @@ pub trait Camera {
     /// Multiple effects can be set at once by combining the bitflags of [CamEffect]
     fn set_effect(&mut self, effect: CamEffect) -> crate::Result<()> {
         unsafe {
-            let r =
-                ctru_sys::CAMU_SetEffect(self.camera_as_raw(), effect.bits(), ctru_sys::CONTEXT_A);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetEffect(self.camera_as_raw(), effect.bits(), ctru_sys::CONTEXT_A))?;
+            Ok(())
         }
     }
 
     /// Sets the contrast of the camera based on the passed [CamContrast] argument.
     fn set_contrast(&mut self, contrast: CamContrast) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetContrast(self.camera_as_raw(), contrast.bits());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetContrast(self.camera_as_raw(), contrast.bits()))?;
+            Ok(())
         }
     }
 
     /// Sets the lens correction of the camera based on the passed [CamLensCorrection] argument.
     fn set_lens_correction(&mut self, lens_correction: CamLensCorrection) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetLensCorrection(self.camera_as_raw(), lens_correction.bits());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetLensCorrection(self.camera_as_raw(), lens_correction.bits()))?;
+            Ok(())
         }
     }
 
     /// Sets the output format of the camera based on the passed [CamOutputFormat] argument.
     fn set_output_format(&mut self, format: CamOutputFormat) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetOutputFormat(
+            LibCtruError(ctru_sys::CAMU_SetOutputFormat(
                 self.camera_as_raw(),
                 format.bits(),
                 ctru_sys::CONTEXT_A,
-            );
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            ))?;
+            Ok(())
         }
     }
 
@@ -696,12 +591,8 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetAutoExposureWindow(self.camera_as_raw(), x, y, width, height);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetAutoExposureWindow(self.camera_as_raw(), x, y, width, height))?;
+            Ok(())
         }
     }
 
@@ -721,25 +612,16 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            let r =
-                ctru_sys::CAMU_SetAutoWhiteBalanceWindow(self.camera_as_raw(), x, y, width, height);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalanceWindow(self.camera_as_raw(), x, y, width, height))?;
+            Ok(())
         }
     }
 
     /// Sets whether the noise filter should be enabled or disabled for the camera
     fn set_noise_filter(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetNoiseFilter(self.camera_as_raw(), enabled);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetNoiseFilter(self.camera_as_raw(), enabled))?;
+            Ok(())
         }
     }
 
@@ -750,12 +632,8 @@ pub trait Camera {
         data: ImageQualityCalibrationData,
     ) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetImageQualityCalibrationData(data.0);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetImageQualityCalibrationData(data.0))?;
+            Ok(())
         }
     }
 
@@ -763,12 +641,8 @@ pub trait Camera {
     fn get_image_quality_calibration_data(&self) -> crate::Result<ImageQualityCalibrationData> {
         unsafe {
             let mut data = ImageQualityCalibrationData::default();
-            let r = ctru_sys::CAMU_GetImageQualityCalibrationData(&mut data.0);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(data)
-            }
+            LibCtruError(ctru_sys::CAMU_GetImageQualityCalibrationData(&mut data.0))?;
+            Ok(data)
         }
     }
 
@@ -776,12 +650,8 @@ pub trait Camera {
     // TODO: Explain sleep camera
     fn set_sleep_camera(&mut self) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_SetSleepCamera(self.camera_as_raw());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_SetSleepCamera(self.camera_as_raw()))?;
+            Ok(())
         }
     }
 
@@ -804,12 +674,8 @@ pub trait Camera {
     ) -> crate::Result<Vec<u8>> {
         let transfer_unit = unsafe {
             let mut buf_size = 0;
-            let r = ctru_sys::CAMU_GetMaxBytes(&mut buf_size, width as i16, height as i16);
-            if r < 0 {
-                Err(crate::Error::from(r))
-            } else {
-                Ok(buf_size)
-            }
+            LibCtruError(ctru_sys::CAMU_GetMaxBytes(&mut buf_size, width as i16, height as i16))?;
+            Ok::<u32, i32>(buf_size)
         }?;
 
         let screen_size = u32::from(width) * u32::from(width) * 2;
@@ -817,83 +683,40 @@ pub trait Camera {
         let mut buf = vec![0u8; usize::try_from(screen_size).unwrap()];
 
         unsafe {
-            let r = ctru_sys::CAMU_SetTransferBytes(
+            LibCtruError(ctru_sys::CAMU_SetTransferBytes(
                 self.port_as_raw(),
                 transfer_unit,
                 width as i16,
                 height as i16,
-            );
-            if r < 0 {
-                return Err(r.into());
-            }
+            ))?;
         };
 
         unsafe {
-            let r = ctru_sys::CAMU_Activate(self.camera_as_raw());
-            if r < 0 {
-                return Err(r.into());
-            }
-        };
-
-        unsafe {
-            let r = ctru_sys::CAMU_ClearBuffer(self.port_as_raw());
-            if r < 0 {
-                return Err(r.into());
-            }
-        };
-
-        unsafe {
-            let r = ctru_sys::CAMU_StartCapture(self.port_as_raw());
-            if r < 0 {
-                return Err(r.into());
-            }
+            LibCtruError(ctru_sys::CAMU_Activate(self.camera_as_raw()))?;
+            LibCtruError(ctru_sys::CAMU_ClearBuffer(self.port_as_raw()))?;
+            LibCtruError(ctru_sys::CAMU_StartCapture(self.port_as_raw()))?;
         };
 
         let receive_event = unsafe {
             let mut completion_handle: Handle = 0;
-            let r = ctru_sys::CAMU_SetReceiving(
+            LibCtruError(ctru_sys::CAMU_SetReceiving(
                 &mut completion_handle,
                 buf.as_mut_ptr() as *mut ::libc::c_void,
                 self.port_as_raw(),
                 screen_size,
                 transfer_unit.try_into().unwrap(),
-            );
-            if r < 0 {
-                Err(crate::Error::from(r))
-            } else {
-                Ok(completion_handle)
-            }
+            ))?;
+            Ok::<Handle, i32>(completion_handle)
         }?;
 
         unsafe {
-            let r = ctru_sys::svcWaitSynchronization(
+            LibCtruError(ctru_sys::svcWaitSynchronization(
                 receive_event,
                 timeout.as_nanos().try_into().unwrap(),
-            );
-            if r < 0 {
-                return Err(r.into());
-            }
-        };
-
-        unsafe {
-            let r = ctru_sys::CAMU_StopCapture(self.port_as_raw());
-            if r < 0 {
-                return Err(r.into());
-            }
-        };
-
-        unsafe {
-            let r = ctru_sys::svcCloseHandle(receive_event);
-            if r < 0 {
-                return Err(r.into());
-            }
-        };
-
-        unsafe {
-            let r = ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE);
-            if r < 0 {
-                return Err(r.into());
-            }
+            ))?;
+            LibCtruError(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
+            LibCtruError(ctru_sys::svcCloseHandle(receive_event))?;
+            LibCtruError(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
         };
 
         Ok(buf)
@@ -910,29 +733,21 @@ impl Cam {
     /// rare in practice.
     pub fn init() -> crate::Result<Cam> {
         unsafe {
-            let r = ctru_sys::camInit();
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(Cam {
-                    inner_cam: InwardCam,
-                    outer_right_cam: OutwardRightCam,
-                    outer_left_cam: OutwardLeftCam,
-                    both_outer_cams: BothOutwardCam,
-                })
-            }
+            LibCtruError(ctru_sys::camInit())?;
+            Ok(Cam {
+                inner_cam: InwardCam,
+                outer_right_cam: OutwardRightCam,
+                outer_left_cam: OutwardLeftCam,
+                both_outer_cams: BothOutwardCam,
+            })
         }
     }
 
     /// Plays the specified sound based on the [CamShutterSoundType] argument
     pub fn play_shutter_sound(&self, sound: CamShutterSoundType) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::CAMU_PlayShutterSound(sound.bits());
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::CAMU_PlayShutterSound(sound.bits()))?;
+            Ok(())
         }
     }
 }

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -274,16 +274,6 @@ impl BothOutwardCam {
             Ok(())
         }
     }
-
-    fn synchronize_vsync_timing(&self) -> crate::Result<()> {
-        unsafe {
-            LibCtruError(ctru_sys::CAMU_SynchronizeVsyncTiming(
-                ctru_sys::SELECT_OUT1,
-                ctru_sys::SELECT_OUT2,
-            ))?;
-            Ok(())
-        }
-    }
 }
 
 impl Camera for BothOutwardCam {

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -3,7 +3,7 @@
 //! The CAM service provides access to the cameras. Cameras can return 2D images
 //! in the form of byte vectors which can be used for display or other usages.
 
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 use crate::services::gspgpu::FramebufferFormat;
 use bitflags::bitflags;
 use ctru_sys::Handle;
@@ -268,7 +268,7 @@ impl BothOutwardCam {
         brightness_synchronization: bool,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetBrightnessSynchronization(
+            ResultCode(ctru_sys::CAMU_SetBrightnessSynchronization(
                 brightness_synchronization,
             ))?;
             Ok(())
@@ -300,7 +300,7 @@ pub trait Camera {
     fn is_busy(&self) -> crate::Result<bool> {
         unsafe {
             let mut is_busy = false;
-            LibCtruResult(ctru_sys::CAMU_IsBusy(&mut is_busy, self.port_as_raw()))?;
+            ResultCode(ctru_sys::CAMU_IsBusy(&mut is_busy, self.port_as_raw()))?;
             Ok(is_busy)
         }
     }
@@ -310,7 +310,7 @@ pub trait Camera {
     fn get_transfer_bytes(&self) -> crate::Result<u32> {
         unsafe {
             let mut transfer_bytes = 0;
-            LibCtruResult(ctru_sys::CAMU_GetTransferBytes(
+            ResultCode(ctru_sys::CAMU_GetTransferBytes(
                 &mut transfer_bytes,
                 self.port_as_raw(),
             ))?;
@@ -322,7 +322,7 @@ pub trait Camera {
     /// [Camera::set_trimming_params]
     fn set_trimming(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetTrimming(self.port_as_raw(), enabled))?;
+            ResultCode(ctru_sys::CAMU_SetTrimming(self.port_as_raw(), enabled))?;
             Ok(())
         }
     }
@@ -331,7 +331,7 @@ pub trait Camera {
     fn is_trimming_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut trimming = false;
-            LibCtruResult(ctru_sys::CAMU_IsTrimming(&mut trimming, self.port_as_raw()))?;
+            ResultCode(ctru_sys::CAMU_IsTrimming(&mut trimming, self.port_as_raw()))?;
             Ok(trimming)
         }
     }
@@ -339,7 +339,7 @@ pub trait Camera {
     /// Sets trimming parameters based on coordinates specified inside a [CamTrimmingParams]
     fn set_trimming_params(&mut self, params: CamTrimmingParams) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetTrimmingParams(
+            ResultCode(ctru_sys::CAMU_SetTrimmingParams(
                 self.port_as_raw(),
                 params.x_start,
                 params.y_start,
@@ -357,7 +357,7 @@ pub trait Camera {
             let mut y_start = 0;
             let mut x_end = 0;
             let mut y_end = 0;
-            LibCtruResult(ctru_sys::CAMU_GetTrimmingParams(
+            ResultCode(ctru_sys::CAMU_GetTrimmingParams(
                 &mut x_start,
                 &mut y_start,
                 &mut x_end,
@@ -385,7 +385,7 @@ pub trait Camera {
         cam_height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetTrimmingParamsCenter(
+            ResultCode(ctru_sys::CAMU_SetTrimmingParamsCenter(
                 self.port_as_raw(),
                 trim_width,
                 trim_height,
@@ -399,7 +399,7 @@ pub trait Camera {
     /// Sets the exposure level of the camera
     fn set_exposure(&mut self, exposure: i8) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetExposure(self.camera_as_raw(), exposure))?;
+            ResultCode(ctru_sys::CAMU_SetExposure(self.camera_as_raw(), exposure))?;
             Ok(())
         }
     }
@@ -407,7 +407,7 @@ pub trait Camera {
     /// Sets the white balance mod of the camera based on the passed [CamWhiteBalance] argument
     fn set_white_balance(&mut self, white_balance: CamWhiteBalance) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetWhiteBalance(
+            ResultCode(ctru_sys::CAMU_SetWhiteBalance(
                 self.camera_as_raw(),
                 white_balance.bits(),
             ))?;
@@ -422,7 +422,7 @@ pub trait Camera {
         white_balance: CamWhiteBalance,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetWhiteBalanceWithoutBaseUp(
+            ResultCode(ctru_sys::CAMU_SetWhiteBalanceWithoutBaseUp(
                 self.camera_as_raw(),
                 white_balance.bits(),
             ))?;
@@ -433,7 +433,7 @@ pub trait Camera {
     /// Sets the sharpness of the camera
     fn set_sharpness(&mut self, sharpness: i8) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetSharpness(self.camera_as_raw(), sharpness))?;
+            ResultCode(ctru_sys::CAMU_SetSharpness(self.camera_as_raw(), sharpness))?;
             Ok(())
         }
     }
@@ -441,7 +441,7 @@ pub trait Camera {
     /// Sets whether auto exposure is enabled or disabled for the camera
     fn set_auto_exposure(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetAutoExposure(
+            ResultCode(ctru_sys::CAMU_SetAutoExposure(
                 self.camera_as_raw(),
                 enabled,
             ))?;
@@ -453,7 +453,7 @@ pub trait Camera {
     fn is_auto_exposure_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            LibCtruResult(ctru_sys::CAMU_IsAutoExposure(
+            ResultCode(ctru_sys::CAMU_IsAutoExposure(
                 &mut enabled,
                 self.camera_as_raw(),
             ))?;
@@ -464,7 +464,7 @@ pub trait Camera {
     /// Sets whether auto white balance is enabled or disabled for the camera
     fn set_auto_white_balance(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetAutoWhiteBalance(
+            ResultCode(ctru_sys::CAMU_SetAutoWhiteBalance(
                 self.camera_as_raw(),
                 enabled,
             ))?;
@@ -476,7 +476,7 @@ pub trait Camera {
     fn is_auto_white_balance_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            LibCtruResult(ctru_sys::CAMU_IsAutoWhiteBalance(
+            ResultCode(ctru_sys::CAMU_IsAutoWhiteBalance(
                 &mut enabled,
                 self.camera_as_raw(),
             ))?;
@@ -487,7 +487,7 @@ pub trait Camera {
     /// Sets the flip direction of the camera's image based on the passed [CamFlip] argument
     fn flip_image(&mut self, flip: CamFlip) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_FlipImage(
+            ResultCode(ctru_sys::CAMU_FlipImage(
                 self.camera_as_raw(),
                 flip.bits(),
                 ctru_sys::CONTEXT_A,
@@ -516,7 +516,7 @@ pub trait Camera {
         crop_1: (i16, i16),
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetDetailSize(
+            ResultCode(ctru_sys::CAMU_SetDetailSize(
                 self.camera_as_raw(),
                 width,
                 height,
@@ -533,7 +533,7 @@ pub trait Camera {
     /// Sets the view size of the camera based on the passed [CamSize] argument.
     fn set_view_size(&mut self, size: CamSize) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetSize(
+            ResultCode(ctru_sys::CAMU_SetSize(
                 self.camera_as_raw(),
                 size.bits(),
                 ctru_sys::CONTEXT_A,
@@ -545,7 +545,7 @@ pub trait Camera {
     /// Sets the frame rate of the camera based on the passed [CamFrameRate] argument.
     fn set_frame_rate(&mut self, frame_rate: CamFrameRate) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetFrameRate(
+            ResultCode(ctru_sys::CAMU_SetFrameRate(
                 self.camera_as_raw(),
                 frame_rate.bits(),
             ))?;
@@ -556,7 +556,7 @@ pub trait Camera {
     /// Sets the photo mode of the camera based on the passed [CamPhotoMode] argument.
     fn set_photo_mode(&mut self, photo_mode: CamPhotoMode) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetPhotoMode(
+            ResultCode(ctru_sys::CAMU_SetPhotoMode(
                 self.camera_as_raw(),
                 photo_mode.bits(),
             ))?;
@@ -569,7 +569,7 @@ pub trait Camera {
     /// Multiple effects can be set at once by combining the bitflags of [CamEffect]
     fn set_effect(&mut self, effect: CamEffect) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetEffect(
+            ResultCode(ctru_sys::CAMU_SetEffect(
                 self.camera_as_raw(),
                 effect.bits(),
                 ctru_sys::CONTEXT_A,
@@ -581,7 +581,7 @@ pub trait Camera {
     /// Sets the contrast of the camera based on the passed [CamContrast] argument.
     fn set_contrast(&mut self, contrast: CamContrast) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetContrast(
+            ResultCode(ctru_sys::CAMU_SetContrast(
                 self.camera_as_raw(),
                 contrast.bits(),
             ))?;
@@ -592,7 +592,7 @@ pub trait Camera {
     /// Sets the lens correction of the camera based on the passed [CamLensCorrection] argument.
     fn set_lens_correction(&mut self, lens_correction: CamLensCorrection) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetLensCorrection(
+            ResultCode(ctru_sys::CAMU_SetLensCorrection(
                 self.camera_as_raw(),
                 lens_correction.bits(),
             ))?;
@@ -603,7 +603,7 @@ pub trait Camera {
     /// Sets the output format of the camera based on the passed [CamOutputFormat] argument.
     fn set_output_format(&mut self, format: CamOutputFormat) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetOutputFormat(
+            ResultCode(ctru_sys::CAMU_SetOutputFormat(
                 self.camera_as_raw(),
                 format.bits(),
                 ctru_sys::CONTEXT_A,
@@ -628,7 +628,7 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetAutoExposureWindow(
+            ResultCode(ctru_sys::CAMU_SetAutoExposureWindow(
                 self.camera_as_raw(),
                 x,
                 y,
@@ -655,7 +655,7 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetAutoWhiteBalanceWindow(
+            ResultCode(ctru_sys::CAMU_SetAutoWhiteBalanceWindow(
                 self.camera_as_raw(),
                 x,
                 y,
@@ -669,7 +669,7 @@ pub trait Camera {
     /// Sets whether the noise filter should be enabled or disabled for the camera
     fn set_noise_filter(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetNoiseFilter(self.camera_as_raw(), enabled))?;
+            ResultCode(ctru_sys::CAMU_SetNoiseFilter(self.camera_as_raw(), enabled))?;
             Ok(())
         }
     }
@@ -681,7 +681,7 @@ pub trait Camera {
         data: ImageQualityCalibrationData,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetImageQualityCalibrationData(data.0))?;
+            ResultCode(ctru_sys::CAMU_SetImageQualityCalibrationData(data.0))?;
             Ok(())
         }
     }
@@ -690,7 +690,7 @@ pub trait Camera {
     fn get_image_quality_calibration_data(&self) -> crate::Result<ImageQualityCalibrationData> {
         unsafe {
             let mut data = ImageQualityCalibrationData::default();
-            LibCtruResult(ctru_sys::CAMU_GetImageQualityCalibrationData(&mut data.0))?;
+            ResultCode(ctru_sys::CAMU_GetImageQualityCalibrationData(&mut data.0))?;
             Ok(data)
         }
     }
@@ -699,7 +699,7 @@ pub trait Camera {
     // TODO: Explain sleep camera
     fn set_sleep_camera(&mut self) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetSleepCamera(self.camera_as_raw()))?;
+            ResultCode(ctru_sys::CAMU_SetSleepCamera(self.camera_as_raw()))?;
             Ok(())
         }
     }
@@ -723,7 +723,7 @@ pub trait Camera {
     ) -> crate::Result<Vec<u8>> {
         let transfer_unit = unsafe {
             let mut buf_size = 0;
-            LibCtruResult(ctru_sys::CAMU_GetMaxBytes(
+            ResultCode(ctru_sys::CAMU_GetMaxBytes(
                 &mut buf_size,
                 width as i16,
                 height as i16,
@@ -736,7 +736,7 @@ pub trait Camera {
         let mut buf = vec![0u8; usize::try_from(screen_size).unwrap()];
 
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_SetTransferBytes(
+            ResultCode(ctru_sys::CAMU_SetTransferBytes(
                 self.port_as_raw(),
                 transfer_unit,
                 width as i16,
@@ -745,14 +745,14 @@ pub trait Camera {
         };
 
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_Activate(self.camera_as_raw()))?;
-            LibCtruResult(ctru_sys::CAMU_ClearBuffer(self.port_as_raw()))?;
-            LibCtruResult(ctru_sys::CAMU_StartCapture(self.port_as_raw()))?;
+            ResultCode(ctru_sys::CAMU_Activate(self.camera_as_raw()))?;
+            ResultCode(ctru_sys::CAMU_ClearBuffer(self.port_as_raw()))?;
+            ResultCode(ctru_sys::CAMU_StartCapture(self.port_as_raw()))?;
         };
 
         let receive_event = unsafe {
             let mut completion_handle: Handle = 0;
-            LibCtruResult(ctru_sys::CAMU_SetReceiving(
+            ResultCode(ctru_sys::CAMU_SetReceiving(
                 &mut completion_handle,
                 buf.as_mut_ptr() as *mut ::libc::c_void,
                 self.port_as_raw(),
@@ -763,13 +763,13 @@ pub trait Camera {
         }?;
 
         unsafe {
-            LibCtruResult(ctru_sys::svcWaitSynchronization(
+            ResultCode(ctru_sys::svcWaitSynchronization(
                 receive_event,
                 timeout.as_nanos().try_into().unwrap(),
             ))?;
-            LibCtruResult(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
-            LibCtruResult(ctru_sys::svcCloseHandle(receive_event))?;
-            LibCtruResult(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
+            ResultCode(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
+            ResultCode(ctru_sys::svcCloseHandle(receive_event))?;
+            ResultCode(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
         };
 
         Ok(buf)
@@ -786,7 +786,7 @@ impl Cam {
     /// rare in practice.
     pub fn init() -> crate::Result<Cam> {
         unsafe {
-            LibCtruResult(ctru_sys::camInit())?;
+            ResultCode(ctru_sys::camInit())?;
             Ok(Cam {
                 inner_cam: InwardCam,
                 outer_right_cam: OutwardRightCam,
@@ -799,7 +799,7 @@ impl Cam {
     /// Plays the specified sound based on the [CamShutterSoundType] argument
     pub fn play_shutter_sound(&self, sound: CamShutterSoundType) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::CAMU_PlayShutterSound(sound.bits()))?;
+            ResultCode(ctru_sys::CAMU_PlayShutterSound(sound.bits()))?;
             Ok(())
         }
     }

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -3,7 +3,7 @@
 //! The CAM service provides access to the cameras. Cameras can return 2D images
 //! in the form of byte vectors which can be used for display or other usages.
 
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 use crate::services::gspgpu::FramebufferFormat;
 use bitflags::bitflags;
 use ctru_sys::Handle;
@@ -268,7 +268,7 @@ impl BothOutwardCam {
         brightness_synchronization: bool,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetBrightnessSynchronization(
+            LibCtruResult(ctru_sys::CAMU_SetBrightnessSynchronization(
                 brightness_synchronization,
             ))?;
             Ok(())
@@ -300,7 +300,7 @@ pub trait Camera {
     fn is_busy(&self) -> crate::Result<bool> {
         unsafe {
             let mut is_busy = false;
-            LibCtruError(ctru_sys::CAMU_IsBusy(&mut is_busy, self.port_as_raw()))?;
+            LibCtruResult(ctru_sys::CAMU_IsBusy(&mut is_busy, self.port_as_raw()))?;
             Ok(is_busy)
         }
     }
@@ -310,7 +310,7 @@ pub trait Camera {
     fn get_transfer_bytes(&self) -> crate::Result<u32> {
         unsafe {
             let mut transfer_bytes = 0;
-            LibCtruError(ctru_sys::CAMU_GetTransferBytes(
+            LibCtruResult(ctru_sys::CAMU_GetTransferBytes(
                 &mut transfer_bytes,
                 self.port_as_raw(),
             ))?;
@@ -322,7 +322,7 @@ pub trait Camera {
     /// [Camera::set_trimming_params]
     fn set_trimming(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetTrimming(self.port_as_raw(), enabled))?;
+            LibCtruResult(ctru_sys::CAMU_SetTrimming(self.port_as_raw(), enabled))?;
             Ok(())
         }
     }
@@ -331,7 +331,7 @@ pub trait Camera {
     fn is_trimming_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut trimming = false;
-            LibCtruError(ctru_sys::CAMU_IsTrimming(&mut trimming, self.port_as_raw()))?;
+            LibCtruResult(ctru_sys::CAMU_IsTrimming(&mut trimming, self.port_as_raw()))?;
             Ok(trimming)
         }
     }
@@ -339,7 +339,7 @@ pub trait Camera {
     /// Sets trimming parameters based on coordinates specified inside a [CamTrimmingParams]
     fn set_trimming_params(&mut self, params: CamTrimmingParams) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetTrimmingParams(
+            LibCtruResult(ctru_sys::CAMU_SetTrimmingParams(
                 self.port_as_raw(),
                 params.x_start,
                 params.y_start,
@@ -357,7 +357,7 @@ pub trait Camera {
             let mut y_start = 0;
             let mut x_end = 0;
             let mut y_end = 0;
-            LibCtruError(ctru_sys::CAMU_GetTrimmingParams(
+            LibCtruResult(ctru_sys::CAMU_GetTrimmingParams(
                 &mut x_start,
                 &mut y_start,
                 &mut x_end,
@@ -385,7 +385,7 @@ pub trait Camera {
         cam_height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetTrimmingParamsCenter(
+            LibCtruResult(ctru_sys::CAMU_SetTrimmingParamsCenter(
                 self.port_as_raw(),
                 trim_width,
                 trim_height,
@@ -399,7 +399,7 @@ pub trait Camera {
     /// Sets the exposure level of the camera
     fn set_exposure(&mut self, exposure: i8) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetExposure(self.camera_as_raw(), exposure))?;
+            LibCtruResult(ctru_sys::CAMU_SetExposure(self.camera_as_raw(), exposure))?;
             Ok(())
         }
     }
@@ -407,7 +407,7 @@ pub trait Camera {
     /// Sets the white balance mod of the camera based on the passed [CamWhiteBalance] argument
     fn set_white_balance(&mut self, white_balance: CamWhiteBalance) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetWhiteBalance(
+            LibCtruResult(ctru_sys::CAMU_SetWhiteBalance(
                 self.camera_as_raw(),
                 white_balance.bits(),
             ))?;
@@ -422,7 +422,7 @@ pub trait Camera {
         white_balance: CamWhiteBalance,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetWhiteBalanceWithoutBaseUp(
+            LibCtruResult(ctru_sys::CAMU_SetWhiteBalanceWithoutBaseUp(
                 self.camera_as_raw(),
                 white_balance.bits(),
             ))?;
@@ -433,7 +433,7 @@ pub trait Camera {
     /// Sets the sharpness of the camera
     fn set_sharpness(&mut self, sharpness: i8) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetSharpness(self.camera_as_raw(), sharpness))?;
+            LibCtruResult(ctru_sys::CAMU_SetSharpness(self.camera_as_raw(), sharpness))?;
             Ok(())
         }
     }
@@ -441,7 +441,7 @@ pub trait Camera {
     /// Sets whether auto exposure is enabled or disabled for the camera
     fn set_auto_exposure(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoExposure(
+            LibCtruResult(ctru_sys::CAMU_SetAutoExposure(
                 self.camera_as_raw(),
                 enabled,
             ))?;
@@ -453,7 +453,7 @@ pub trait Camera {
     fn is_auto_exposure_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            LibCtruError(ctru_sys::CAMU_IsAutoExposure(
+            LibCtruResult(ctru_sys::CAMU_IsAutoExposure(
                 &mut enabled,
                 self.camera_as_raw(),
             ))?;
@@ -464,7 +464,7 @@ pub trait Camera {
     /// Sets whether auto white balance is enabled or disabled for the camera
     fn set_auto_white_balance(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalance(
+            LibCtruResult(ctru_sys::CAMU_SetAutoWhiteBalance(
                 self.camera_as_raw(),
                 enabled,
             ))?;
@@ -476,7 +476,7 @@ pub trait Camera {
     fn is_auto_white_balance_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            LibCtruError(ctru_sys::CAMU_IsAutoWhiteBalance(
+            LibCtruResult(ctru_sys::CAMU_IsAutoWhiteBalance(
                 &mut enabled,
                 self.camera_as_raw(),
             ))?;
@@ -487,7 +487,7 @@ pub trait Camera {
     /// Sets the flip direction of the camera's image based on the passed [CamFlip] argument
     fn flip_image(&mut self, flip: CamFlip) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_FlipImage(
+            LibCtruResult(ctru_sys::CAMU_FlipImage(
                 self.camera_as_raw(),
                 flip.bits(),
                 ctru_sys::CONTEXT_A,
@@ -516,7 +516,7 @@ pub trait Camera {
         crop_1: (i16, i16),
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetDetailSize(
+            LibCtruResult(ctru_sys::CAMU_SetDetailSize(
                 self.camera_as_raw(),
                 width,
                 height,
@@ -533,7 +533,7 @@ pub trait Camera {
     /// Sets the view size of the camera based on the passed [CamSize] argument.
     fn set_view_size(&mut self, size: CamSize) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetSize(
+            LibCtruResult(ctru_sys::CAMU_SetSize(
                 self.camera_as_raw(),
                 size.bits(),
                 ctru_sys::CONTEXT_A,
@@ -545,7 +545,7 @@ pub trait Camera {
     /// Sets the frame rate of the camera based on the passed [CamFrameRate] argument.
     fn set_frame_rate(&mut self, frame_rate: CamFrameRate) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetFrameRate(
+            LibCtruResult(ctru_sys::CAMU_SetFrameRate(
                 self.camera_as_raw(),
                 frame_rate.bits(),
             ))?;
@@ -556,7 +556,7 @@ pub trait Camera {
     /// Sets the photo mode of the camera based on the passed [CamPhotoMode] argument.
     fn set_photo_mode(&mut self, photo_mode: CamPhotoMode) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetPhotoMode(
+            LibCtruResult(ctru_sys::CAMU_SetPhotoMode(
                 self.camera_as_raw(),
                 photo_mode.bits(),
             ))?;
@@ -569,7 +569,7 @@ pub trait Camera {
     /// Multiple effects can be set at once by combining the bitflags of [CamEffect]
     fn set_effect(&mut self, effect: CamEffect) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetEffect(
+            LibCtruResult(ctru_sys::CAMU_SetEffect(
                 self.camera_as_raw(),
                 effect.bits(),
                 ctru_sys::CONTEXT_A,
@@ -581,7 +581,7 @@ pub trait Camera {
     /// Sets the contrast of the camera based on the passed [CamContrast] argument.
     fn set_contrast(&mut self, contrast: CamContrast) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetContrast(
+            LibCtruResult(ctru_sys::CAMU_SetContrast(
                 self.camera_as_raw(),
                 contrast.bits(),
             ))?;
@@ -592,7 +592,7 @@ pub trait Camera {
     /// Sets the lens correction of the camera based on the passed [CamLensCorrection] argument.
     fn set_lens_correction(&mut self, lens_correction: CamLensCorrection) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetLensCorrection(
+            LibCtruResult(ctru_sys::CAMU_SetLensCorrection(
                 self.camera_as_raw(),
                 lens_correction.bits(),
             ))?;
@@ -603,7 +603,7 @@ pub trait Camera {
     /// Sets the output format of the camera based on the passed [CamOutputFormat] argument.
     fn set_output_format(&mut self, format: CamOutputFormat) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetOutputFormat(
+            LibCtruResult(ctru_sys::CAMU_SetOutputFormat(
                 self.camera_as_raw(),
                 format.bits(),
                 ctru_sys::CONTEXT_A,
@@ -628,7 +628,7 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoExposureWindow(
+            LibCtruResult(ctru_sys::CAMU_SetAutoExposureWindow(
                 self.camera_as_raw(),
                 x,
                 y,
@@ -655,7 +655,7 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalanceWindow(
+            LibCtruResult(ctru_sys::CAMU_SetAutoWhiteBalanceWindow(
                 self.camera_as_raw(),
                 x,
                 y,
@@ -669,7 +669,7 @@ pub trait Camera {
     /// Sets whether the noise filter should be enabled or disabled for the camera
     fn set_noise_filter(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetNoiseFilter(self.camera_as_raw(), enabled))?;
+            LibCtruResult(ctru_sys::CAMU_SetNoiseFilter(self.camera_as_raw(), enabled))?;
             Ok(())
         }
     }
@@ -681,7 +681,7 @@ pub trait Camera {
         data: ImageQualityCalibrationData,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetImageQualityCalibrationData(data.0))?;
+            LibCtruResult(ctru_sys::CAMU_SetImageQualityCalibrationData(data.0))?;
             Ok(())
         }
     }
@@ -690,7 +690,7 @@ pub trait Camera {
     fn get_image_quality_calibration_data(&self) -> crate::Result<ImageQualityCalibrationData> {
         unsafe {
             let mut data = ImageQualityCalibrationData::default();
-            LibCtruError(ctru_sys::CAMU_GetImageQualityCalibrationData(&mut data.0))?;
+            LibCtruResult(ctru_sys::CAMU_GetImageQualityCalibrationData(&mut data.0))?;
             Ok(data)
         }
     }
@@ -699,7 +699,7 @@ pub trait Camera {
     // TODO: Explain sleep camera
     fn set_sleep_camera(&mut self) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetSleepCamera(self.camera_as_raw()))?;
+            LibCtruResult(ctru_sys::CAMU_SetSleepCamera(self.camera_as_raw()))?;
             Ok(())
         }
     }
@@ -723,7 +723,7 @@ pub trait Camera {
     ) -> crate::Result<Vec<u8>> {
         let transfer_unit = unsafe {
             let mut buf_size = 0;
-            LibCtruError(ctru_sys::CAMU_GetMaxBytes(
+            LibCtruResult(ctru_sys::CAMU_GetMaxBytes(
                 &mut buf_size,
                 width as i16,
                 height as i16,
@@ -736,7 +736,7 @@ pub trait Camera {
         let mut buf = vec![0u8; usize::try_from(screen_size).unwrap()];
 
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetTransferBytes(
+            LibCtruResult(ctru_sys::CAMU_SetTransferBytes(
                 self.port_as_raw(),
                 transfer_unit,
                 width as i16,
@@ -745,14 +745,14 @@ pub trait Camera {
         };
 
         unsafe {
-            LibCtruError(ctru_sys::CAMU_Activate(self.camera_as_raw()))?;
-            LibCtruError(ctru_sys::CAMU_ClearBuffer(self.port_as_raw()))?;
-            LibCtruError(ctru_sys::CAMU_StartCapture(self.port_as_raw()))?;
+            LibCtruResult(ctru_sys::CAMU_Activate(self.camera_as_raw()))?;
+            LibCtruResult(ctru_sys::CAMU_ClearBuffer(self.port_as_raw()))?;
+            LibCtruResult(ctru_sys::CAMU_StartCapture(self.port_as_raw()))?;
         };
 
         let receive_event = unsafe {
             let mut completion_handle: Handle = 0;
-            LibCtruError(ctru_sys::CAMU_SetReceiving(
+            LibCtruResult(ctru_sys::CAMU_SetReceiving(
                 &mut completion_handle,
                 buf.as_mut_ptr() as *mut ::libc::c_void,
                 self.port_as_raw(),
@@ -763,13 +763,13 @@ pub trait Camera {
         }?;
 
         unsafe {
-            LibCtruError(ctru_sys::svcWaitSynchronization(
+            LibCtruResult(ctru_sys::svcWaitSynchronization(
                 receive_event,
                 timeout.as_nanos().try_into().unwrap(),
             ))?;
-            LibCtruError(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
-            LibCtruError(ctru_sys::svcCloseHandle(receive_event))?;
-            LibCtruError(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
+            LibCtruResult(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
+            LibCtruResult(ctru_sys::svcCloseHandle(receive_event))?;
+            LibCtruResult(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
         };
 
         Ok(buf)
@@ -786,7 +786,7 @@ impl Cam {
     /// rare in practice.
     pub fn init() -> crate::Result<Cam> {
         unsafe {
-            LibCtruError(ctru_sys::camInit())?;
+            LibCtruResult(ctru_sys::camInit())?;
             Ok(Cam {
                 inner_cam: InwardCam,
                 outer_right_cam: OutwardRightCam,
@@ -799,7 +799,7 @@ impl Cam {
     /// Plays the specified sound based on the [CamShutterSoundType] argument
     pub fn play_shutter_sound(&self, sound: CamShutterSoundType) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_PlayShutterSound(sound.bits()))?;
+            LibCtruResult(ctru_sys::CAMU_PlayShutterSound(sound.bits()))?;
             Ok(())
         }
     }

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -3,11 +3,11 @@
 //! The CAM service provides access to the cameras. Cameras can return 2D images
 //! in the form of byte vectors which can be used for display or other usages.
 
+use crate::error::LibCtruError;
 use crate::services::gspgpu::FramebufferFormat;
 use bitflags::bitflags;
 use ctru_sys::Handle;
 use std::time::Duration;
-use crate::error::LibCtruError;
 
 /// A reference-counted handle to the CAM service and the usable cameras.
 /// The service is closed when all instances of this struct fall out of scope.
@@ -268,14 +268,19 @@ impl BothOutwardCam {
         brightness_synchronization: bool,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetBrightnessSynchronization(brightness_synchronization))?;
+            LibCtruError(ctru_sys::CAMU_SetBrightnessSynchronization(
+                brightness_synchronization,
+            ))?;
             Ok(())
         }
     }
 
     fn synchronize_vsync_timing(&self) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SynchronizeVsyncTiming(ctru_sys::SELECT_OUT1, ctru_sys::SELECT_OUT2))?;
+            LibCtruError(ctru_sys::CAMU_SynchronizeVsyncTiming(
+                ctru_sys::SELECT_OUT1,
+                ctru_sys::SELECT_OUT2,
+            ))?;
             Ok(())
         }
     }
@@ -315,7 +320,10 @@ pub trait Camera {
     fn get_transfer_bytes(&self) -> crate::Result<u32> {
         unsafe {
             let mut transfer_bytes = 0;
-            LibCtruError(ctru_sys::CAMU_GetTransferBytes(&mut transfer_bytes, self.port_as_raw()))?;
+            LibCtruError(ctru_sys::CAMU_GetTransferBytes(
+                &mut transfer_bytes,
+                self.port_as_raw(),
+            ))?;
             Ok(transfer_bytes)
         }
     }
@@ -409,7 +417,10 @@ pub trait Camera {
     /// Sets the white balance mod of the camera based on the passed [CamWhiteBalance] argument
     fn set_white_balance(&mut self, white_balance: CamWhiteBalance) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetWhiteBalance(self.camera_as_raw(), white_balance.bits()))?;
+            LibCtruError(ctru_sys::CAMU_SetWhiteBalance(
+                self.camera_as_raw(),
+                white_balance.bits(),
+            ))?;
             Ok(())
         }
     }
@@ -440,7 +451,10 @@ pub trait Camera {
     /// Sets whether auto exposure is enabled or disabled for the camera
     fn set_auto_exposure(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoExposure(self.camera_as_raw(), enabled))?;
+            LibCtruError(ctru_sys::CAMU_SetAutoExposure(
+                self.camera_as_raw(),
+                enabled,
+            ))?;
             Ok(())
         }
     }
@@ -449,7 +463,10 @@ pub trait Camera {
     fn is_auto_exposure_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            LibCtruError(ctru_sys::CAMU_IsAutoExposure(&mut enabled, self.camera_as_raw()))?;
+            LibCtruError(ctru_sys::CAMU_IsAutoExposure(
+                &mut enabled,
+                self.camera_as_raw(),
+            ))?;
             Ok(enabled)
         }
     }
@@ -457,7 +474,10 @@ pub trait Camera {
     /// Sets whether auto white balance is enabled or disabled for the camera
     fn set_auto_white_balance(&mut self, enabled: bool) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalance(self.camera_as_raw(), enabled))?;
+            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalance(
+                self.camera_as_raw(),
+                enabled,
+            ))?;
             Ok(())
         }
     }
@@ -466,7 +486,10 @@ pub trait Camera {
     fn is_auto_white_balance_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut enabled = false;
-            LibCtruError(ctru_sys::CAMU_IsAutoWhiteBalance(&mut enabled, self.camera_as_raw()))?;
+            LibCtruError(ctru_sys::CAMU_IsAutoWhiteBalance(
+                &mut enabled,
+                self.camera_as_raw(),
+            ))?;
             Ok(enabled)
         }
     }
@@ -474,7 +497,11 @@ pub trait Camera {
     /// Sets the flip direction of the camera's image based on the passed [CamFlip] argument
     fn flip_image(&mut self, flip: CamFlip) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_FlipImage(self.camera_as_raw(), flip.bits(), ctru_sys::CONTEXT_A))?;
+            LibCtruError(ctru_sys::CAMU_FlipImage(
+                self.camera_as_raw(),
+                flip.bits(),
+                ctru_sys::CONTEXT_A,
+            ))?;
             Ok(())
         }
     }
@@ -516,7 +543,11 @@ pub trait Camera {
     /// Sets the view size of the camera based on the passed [CamSize] argument.
     fn set_view_size(&mut self, size: CamSize) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetSize(self.camera_as_raw(), size.bits(), ctru_sys::CONTEXT_A))?;
+            LibCtruError(ctru_sys::CAMU_SetSize(
+                self.camera_as_raw(),
+                size.bits(),
+                ctru_sys::CONTEXT_A,
+            ))?;
             Ok(())
         }
     }
@@ -524,7 +555,10 @@ pub trait Camera {
     /// Sets the frame rate of the camera based on the passed [CamFrameRate] argument.
     fn set_frame_rate(&mut self, frame_rate: CamFrameRate) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetFrameRate(self.camera_as_raw(), frame_rate.bits()))?;
+            LibCtruError(ctru_sys::CAMU_SetFrameRate(
+                self.camera_as_raw(),
+                frame_rate.bits(),
+            ))?;
             Ok(())
         }
     }
@@ -532,7 +566,10 @@ pub trait Camera {
     /// Sets the photo mode of the camera based on the passed [CamPhotoMode] argument.
     fn set_photo_mode(&mut self, photo_mode: CamPhotoMode) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetPhotoMode(self.camera_as_raw(), photo_mode.bits()))?;
+            LibCtruError(ctru_sys::CAMU_SetPhotoMode(
+                self.camera_as_raw(),
+                photo_mode.bits(),
+            ))?;
             Ok(())
         }
     }
@@ -542,7 +579,11 @@ pub trait Camera {
     /// Multiple effects can be set at once by combining the bitflags of [CamEffect]
     fn set_effect(&mut self, effect: CamEffect) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetEffect(self.camera_as_raw(), effect.bits(), ctru_sys::CONTEXT_A))?;
+            LibCtruError(ctru_sys::CAMU_SetEffect(
+                self.camera_as_raw(),
+                effect.bits(),
+                ctru_sys::CONTEXT_A,
+            ))?;
             Ok(())
         }
     }
@@ -550,7 +591,10 @@ pub trait Camera {
     /// Sets the contrast of the camera based on the passed [CamContrast] argument.
     fn set_contrast(&mut self, contrast: CamContrast) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetContrast(self.camera_as_raw(), contrast.bits()))?;
+            LibCtruError(ctru_sys::CAMU_SetContrast(
+                self.camera_as_raw(),
+                contrast.bits(),
+            ))?;
             Ok(())
         }
     }
@@ -558,7 +602,10 @@ pub trait Camera {
     /// Sets the lens correction of the camera based on the passed [CamLensCorrection] argument.
     fn set_lens_correction(&mut self, lens_correction: CamLensCorrection) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetLensCorrection(self.camera_as_raw(), lens_correction.bits()))?;
+            LibCtruError(ctru_sys::CAMU_SetLensCorrection(
+                self.camera_as_raw(),
+                lens_correction.bits(),
+            ))?;
             Ok(())
         }
     }
@@ -591,7 +638,13 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoExposureWindow(self.camera_as_raw(), x, y, width, height))?;
+            LibCtruError(ctru_sys::CAMU_SetAutoExposureWindow(
+                self.camera_as_raw(),
+                x,
+                y,
+                width,
+                height,
+            ))?;
             Ok(())
         }
     }
@@ -612,7 +665,13 @@ pub trait Camera {
         height: i16,
     ) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalanceWindow(self.camera_as_raw(), x, y, width, height))?;
+            LibCtruError(ctru_sys::CAMU_SetAutoWhiteBalanceWindow(
+                self.camera_as_raw(),
+                x,
+                y,
+                width,
+                height,
+            ))?;
             Ok(())
         }
     }
@@ -674,7 +733,11 @@ pub trait Camera {
     ) -> crate::Result<Vec<u8>> {
         let transfer_unit = unsafe {
             let mut buf_size = 0;
-            LibCtruError(ctru_sys::CAMU_GetMaxBytes(&mut buf_size, width as i16, height as i16))?;
+            LibCtruError(ctru_sys::CAMU_GetMaxBytes(
+                &mut buf_size,
+                width as i16,
+                height as i16,
+            ))?;
             Ok::<u32, i32>(buf_size)
         }?;
 

--- a/ctru-rs/src/services/cfgu.rs
+++ b/ctru-rs/src/services/cfgu.rs
@@ -2,6 +2,8 @@
 //!
 //! This module contains basic methods to retrieve and change configuration from the console.
 
+use crate::error::LibCtruError;
+
 #[derive(Copy, Clone, Debug)]
 #[repr(u32)]
 pub enum Region {
@@ -60,77 +62,48 @@ impl Cfgu {
     /// as many times as desired and the service will not exit until all
     /// instances of Cfgu drop out of scope.
     pub fn init() -> crate::Result<Cfgu> {
-        unsafe {
-            let r = ctru_sys::cfguInit();
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(Cfgu(()))
-            }
-        }
+        LibCtruError(unsafe { ctru_sys::cfguInit() })?;
+        Ok(Cfgu(()))
     }
 
     /// Gets system region from secure info
     pub fn get_region(&self) -> crate::Result<Region> {
         let mut region: u8 = 0;
 
-        let r = unsafe { ctru_sys::CFGU_SecureInfoGetRegion(&mut region) };
-        if r < 0 {
-            Err(r.into())
-        } else {
-            // The system shouldn't give an invalid value
-            Ok(Region::try_from(region).unwrap())
-        }
+        LibCtruError(unsafe { ctru_sys::CFGU_SecureInfoGetRegion(&mut region) })?;
+        Ok(Region::try_from(region).unwrap())
     }
 
     /// Gets system's model
     pub fn get_model(&self) -> crate::Result<SystemModel> {
         let mut model: u8 = 0;
 
-        let r = unsafe { ctru_sys::CFGU_GetSystemModel(&mut model) };
-        if r < 0 {
-            Err(r.into())
-        } else {
-            // The system shouldn't give an invalid value
-            Ok(SystemModel::try_from(model).unwrap())
-        }
+        LibCtruError(unsafe { ctru_sys::CFGU_GetSystemModel(&mut model) })?;
+        Ok(SystemModel::try_from(model).unwrap())
     }
 
     /// Gets system's language
     pub fn get_language(&self) -> crate::Result<Language> {
         let mut language: u8 = 0;
 
-        let r = unsafe { ctru_sys::CFGU_GetSystemLanguage(&mut language) };
-        if r < 0 {
-            Err(r.into())
-        } else {
-            // The system shouldn't give an invalid value
-            Ok(Language::try_from(language).unwrap())
-        }
+        LibCtruError(unsafe { ctru_sys::CFGU_GetSystemLanguage(&mut language) })?;
+        Ok(Language::try_from(language).unwrap())
     }
 
     /// Checks if NFC is supported by the console
     pub fn is_nfc_supported(&self) -> crate::Result<bool> {
         let mut supported: bool = false;
 
-        let r = unsafe { ctru_sys::CFGU_IsNFCSupported(&mut supported) };
-        if r < 0 {
-            Err(r.into())
-        } else {
-            Ok(supported)
-        }
+        LibCtruError(unsafe { ctru_sys::CFGU_IsNFCSupported(&mut supported) })?;
+        Ok(supported)
     }
 
     /// Check if the console is from the 2DS family (2DS, New2DS, New2DSXL)
     pub fn is_2ds_family(&self) -> crate::Result<bool> {
         let mut is_2ds_family: u8 = 0;
 
-        let r = unsafe { ctru_sys::CFGU_GetModelNintendo2DS(&mut is_2ds_family) };
-        if r < 0 {
-            Err(r.into())
-        } else {
-            Ok(is_2ds_family == 0)
-        }
+        LibCtruError(unsafe { ctru_sys::CFGU_GetModelNintendo2DS(&mut is_2ds_family) })?;
+        Ok(is_2ds_family == 0)
     }
 }
 

--- a/ctru-rs/src/services/cfgu.rs
+++ b/ctru-rs/src/services/cfgu.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains basic methods to retrieve and change configuration from the console.
 
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(u32)]
@@ -62,7 +62,7 @@ impl Cfgu {
     /// as many times as desired and the service will not exit until all
     /// instances of Cfgu drop out of scope.
     pub fn init() -> crate::Result<Cfgu> {
-        LibCtruError(unsafe { ctru_sys::cfguInit() })?;
+        LibCtruResult(unsafe { ctru_sys::cfguInit() })?;
         Ok(Cfgu(()))
     }
 
@@ -70,7 +70,7 @@ impl Cfgu {
     pub fn get_region(&self) -> crate::Result<Region> {
         let mut region: u8 = 0;
 
-        LibCtruError(unsafe { ctru_sys::CFGU_SecureInfoGetRegion(&mut region) })?;
+        LibCtruResult(unsafe { ctru_sys::CFGU_SecureInfoGetRegion(&mut region) })?;
         Ok(Region::try_from(region).unwrap())
     }
 
@@ -78,7 +78,7 @@ impl Cfgu {
     pub fn get_model(&self) -> crate::Result<SystemModel> {
         let mut model: u8 = 0;
 
-        LibCtruError(unsafe { ctru_sys::CFGU_GetSystemModel(&mut model) })?;
+        LibCtruResult(unsafe { ctru_sys::CFGU_GetSystemModel(&mut model) })?;
         Ok(SystemModel::try_from(model).unwrap())
     }
 
@@ -86,7 +86,7 @@ impl Cfgu {
     pub fn get_language(&self) -> crate::Result<Language> {
         let mut language: u8 = 0;
 
-        LibCtruError(unsafe { ctru_sys::CFGU_GetSystemLanguage(&mut language) })?;
+        LibCtruResult(unsafe { ctru_sys::CFGU_GetSystemLanguage(&mut language) })?;
         Ok(Language::try_from(language).unwrap())
     }
 
@@ -94,7 +94,7 @@ impl Cfgu {
     pub fn is_nfc_supported(&self) -> crate::Result<bool> {
         let mut supported: bool = false;
 
-        LibCtruError(unsafe { ctru_sys::CFGU_IsNFCSupported(&mut supported) })?;
+        LibCtruResult(unsafe { ctru_sys::CFGU_IsNFCSupported(&mut supported) })?;
         Ok(supported)
     }
 
@@ -102,7 +102,7 @@ impl Cfgu {
     pub fn is_2ds_family(&self) -> crate::Result<bool> {
         let mut is_2ds_family: u8 = 0;
 
-        LibCtruError(unsafe { ctru_sys::CFGU_GetModelNintendo2DS(&mut is_2ds_family) })?;
+        LibCtruResult(unsafe { ctru_sys::CFGU_GetModelNintendo2DS(&mut is_2ds_family) })?;
         Ok(is_2ds_family == 0)
     }
 }

--- a/ctru-rs/src/services/cfgu.rs
+++ b/ctru-rs/src/services/cfgu.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains basic methods to retrieve and change configuration from the console.
 
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(u32)]
@@ -62,7 +62,7 @@ impl Cfgu {
     /// as many times as desired and the service will not exit until all
     /// instances of Cfgu drop out of scope.
     pub fn init() -> crate::Result<Cfgu> {
-        LibCtruResult(unsafe { ctru_sys::cfguInit() })?;
+        ResultCode(unsafe { ctru_sys::cfguInit() })?;
         Ok(Cfgu(()))
     }
 
@@ -70,7 +70,7 @@ impl Cfgu {
     pub fn get_region(&self) -> crate::Result<Region> {
         let mut region: u8 = 0;
 
-        LibCtruResult(unsafe { ctru_sys::CFGU_SecureInfoGetRegion(&mut region) })?;
+        ResultCode(unsafe { ctru_sys::CFGU_SecureInfoGetRegion(&mut region) })?;
         Ok(Region::try_from(region).unwrap())
     }
 
@@ -78,7 +78,7 @@ impl Cfgu {
     pub fn get_model(&self) -> crate::Result<SystemModel> {
         let mut model: u8 = 0;
 
-        LibCtruResult(unsafe { ctru_sys::CFGU_GetSystemModel(&mut model) })?;
+        ResultCode(unsafe { ctru_sys::CFGU_GetSystemModel(&mut model) })?;
         Ok(SystemModel::try_from(model).unwrap())
     }
 
@@ -86,7 +86,7 @@ impl Cfgu {
     pub fn get_language(&self) -> crate::Result<Language> {
         let mut language: u8 = 0;
 
-        LibCtruResult(unsafe { ctru_sys::CFGU_GetSystemLanguage(&mut language) })?;
+        ResultCode(unsafe { ctru_sys::CFGU_GetSystemLanguage(&mut language) })?;
         Ok(Language::try_from(language).unwrap())
     }
 
@@ -94,7 +94,7 @@ impl Cfgu {
     pub fn is_nfc_supported(&self) -> crate::Result<bool> {
         let mut supported: bool = false;
 
-        LibCtruResult(unsafe { ctru_sys::CFGU_IsNFCSupported(&mut supported) })?;
+        ResultCode(unsafe { ctru_sys::CFGU_IsNFCSupported(&mut supported) })?;
         Ok(supported)
     }
 
@@ -102,7 +102,7 @@ impl Cfgu {
     pub fn is_2ds_family(&self) -> crate::Result<bool> {
         let mut is_2ds_family: u8 = 0;
 
-        LibCtruResult(unsafe { ctru_sys::CFGU_GetModelNintendo2DS(&mut is_2ds_family) })?;
+        ResultCode(unsafe { ctru_sys::CFGU_GetModelNintendo2DS(&mut is_2ds_family) })?;
         Ok(is_2ds_family == 0)
     }
 }

--- a/ctru-rs/src/services/hid.rs
+++ b/ctru-rs/src/services/hid.rs
@@ -4,7 +4,7 @@
 //! and circle pad information. It also provides information from the sound volume slider,
 //! the accelerometer, and the gyroscope.
 
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 bitflags::bitflags! {
     /// A set of flags corresponding to the button and directional pad
     /// inputs on the 3DS
@@ -63,7 +63,7 @@ pub struct CirclePosition(ctru_sys::circlePosition);
 impl Hid {
     pub fn init() -> crate::Result<Hid> {
         unsafe {
-            LibCtruError(ctru_sys::hidInit())?;
+            LibCtruResult(ctru_sys::hidInit())?;
             Ok(Hid(()))
         }
     }

--- a/ctru-rs/src/services/hid.rs
+++ b/ctru-rs/src/services/hid.rs
@@ -4,7 +4,7 @@
 //! and circle pad information. It also provides information from the sound volume slider,
 //! the accelerometer, and the gyroscope.
 
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 bitflags::bitflags! {
     /// A set of flags corresponding to the button and directional pad
     /// inputs on the 3DS
@@ -63,7 +63,7 @@ pub struct CirclePosition(ctru_sys::circlePosition);
 impl Hid {
     pub fn init() -> crate::Result<Hid> {
         unsafe {
-            LibCtruResult(ctru_sys::hidInit())?;
+            ResultCode(ctru_sys::hidInit())?;
             Ok(Hid(()))
         }
     }

--- a/ctru-rs/src/services/hid.rs
+++ b/ctru-rs/src/services/hid.rs
@@ -4,6 +4,7 @@
 //! and circle pad information. It also provides information from the sound volume slider,
 //! the accelerometer, and the gyroscope.
 
+use crate::error::LibCtruError;
 bitflags::bitflags! {
     /// A set of flags corresponding to the button and directional pad
     /// inputs on the 3DS
@@ -62,12 +63,8 @@ pub struct CirclePosition(ctru_sys::circlePosition);
 impl Hid {
     pub fn init() -> crate::Result<Hid> {
         unsafe {
-            let r = ctru_sys::hidInit();
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(Hid(()))
-            }
+            LibCtruError(ctru_sys::hidInit())?;
+            Ok(Hid(()))
         }
     }
 

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -4,7 +4,7 @@
 //! As such, it is initialized by default in `ctru::init` instead of having a safety handler
 //! See also <https://www.3dbrew.org/wiki/Process_Services>
 
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 
 #[repr(u32)]
 pub enum AESAlgorithm {
@@ -33,19 +33,19 @@ pub enum AESKeyType {
 pub fn local_friend_code_seed() -> crate::Result<u64> {
     let mut seed: u64 = 0;
 
-    LibCtruError(unsafe { ctru_sys::PS_GetLocalFriendCodeSeed(&mut seed) })?;
+    LibCtruResult(unsafe { ctru_sys::PS_GetLocalFriendCodeSeed(&mut seed) })?;
     Ok(seed)
 }
 
 pub fn device_id() -> crate::Result<u32> {
     let mut id: u32 = 0;
 
-    LibCtruError(unsafe { ctru_sys::PS_GetDeviceId(&mut id) })?;
+    LibCtruResult(unsafe { ctru_sys::PS_GetDeviceId(&mut id) })?;
     Ok(id)
 }
 
 pub fn generate_random_bytes(out: &mut [u8]) -> crate::Result<()> {
-    LibCtruError(unsafe {
+    LibCtruResult(unsafe {
         ctru_sys::PS_GenerateRandomBytes(out as *mut _ as *mut _, out.len() as u32)
     })?;
     Ok(())

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -45,7 +45,9 @@ pub fn device_id() -> crate::Result<u32> {
 }
 
 pub fn generate_random_bytes(out: &mut [u8]) -> crate::Result<()> {
-    LibCtruError(unsafe { ctru_sys::PS_GenerateRandomBytes(out as *mut _ as *mut _, out.len() as u32) })?;
+    LibCtruError(unsafe {
+        ctru_sys::PS_GenerateRandomBytes(out as *mut _ as *mut _, out.len() as u32)
+    })?;
     Ok(())
 }
 

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -4,7 +4,7 @@
 //! As such, it is initialized by default in `ctru::init` instead of having a safety handler
 //! See also <https://www.3dbrew.org/wiki/Process_Services>
 
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 
 #[repr(u32)]
 pub enum AESAlgorithm {
@@ -33,19 +33,19 @@ pub enum AESKeyType {
 pub fn local_friend_code_seed() -> crate::Result<u64> {
     let mut seed: u64 = 0;
 
-    LibCtruResult(unsafe { ctru_sys::PS_GetLocalFriendCodeSeed(&mut seed) })?;
+    ResultCode(unsafe { ctru_sys::PS_GetLocalFriendCodeSeed(&mut seed) })?;
     Ok(seed)
 }
 
 pub fn device_id() -> crate::Result<u32> {
     let mut id: u32 = 0;
 
-    LibCtruResult(unsafe { ctru_sys::PS_GetDeviceId(&mut id) })?;
+    ResultCode(unsafe { ctru_sys::PS_GetDeviceId(&mut id) })?;
     Ok(id)
 }
 
 pub fn generate_random_bytes(out: &mut [u8]) -> crate::Result<()> {
-    LibCtruResult(unsafe {
+    ResultCode(unsafe {
         ctru_sys::PS_GenerateRandomBytes(out as *mut _ as *mut _, out.len() as u32)
     })?;
     Ok(())

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -4,6 +4,8 @@
 //! As such, it is initialized by default in `ctru::init` instead of having a safety handler
 //! See also <https://www.3dbrew.org/wiki/Process_Services>
 
+use crate::error::LibCtruError;
+
 #[repr(u32)]
 pub enum AESAlgorithm {
     CbcEnc,
@@ -31,32 +33,20 @@ pub enum AESKeyType {
 pub fn local_friend_code_seed() -> crate::Result<u64> {
     let mut seed: u64 = 0;
 
-    let r = unsafe { ctru_sys::PS_GetLocalFriendCodeSeed(&mut seed) };
-    if r < 0 {
-        Err(r.into())
-    } else {
-        Ok(seed)
-    }
+    LibCtruError(unsafe { ctru_sys::PS_GetLocalFriendCodeSeed(&mut seed) })?;
+    Ok(seed)
 }
 
 pub fn device_id() -> crate::Result<u32> {
     let mut id: u32 = 0;
 
-    let r = unsafe { ctru_sys::PS_GetDeviceId(&mut id) };
-    if r < 0 {
-        Err(r.into())
-    } else {
-        Ok(id)
-    }
+    LibCtruError(unsafe { ctru_sys::PS_GetDeviceId(&mut id) })?;
+    Ok(id)
 }
 
 pub fn generate_random_bytes(out: &mut [u8]) -> crate::Result<()> {
-    let r = unsafe { ctru_sys::PS_GenerateRandomBytes(out as *mut _ as *mut _, out.len() as u32) };
-    if r < 0 {
-        Err(r.into())
-    } else {
-        Ok(())
-    }
+    LibCtruError(unsafe { ctru_sys::PS_GenerateRandomBytes(out as *mut _ as *mut _, out.len() as u32) })?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -3,9 +3,9 @@ use once_cell::sync::Lazy;
 use std::net::Ipv4Addr;
 use std::sync::Mutex;
 
+use crate::error::LibCtruError;
 use crate::services::ServiceReference;
 use crate::Error;
-use crate::error::LibCtruError;
 
 /// Soc service. Initializing this service will enable the use of network sockets and utilities
 /// such as those found in `std::net`. The service will be closed when this struct is is dropped.

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 
 use crate::services::ServiceReference;
 use crate::Error;
+use crate::error::LibCtruError;
 
 /// Soc service. Initializing this service will enable the use of network sockets and utilities
 /// such as those found in `std::net`. The service will be closed when this struct is is dropped.
@@ -38,10 +39,7 @@ impl Soc {
             false,
             || {
                 let soc_mem = unsafe { memalign(0x1000, num_bytes) } as *mut u32;
-                let r = unsafe { ctru_sys::socInit(soc_mem, num_bytes as u32) };
-                if r < 0 {
-                    return Err(r.into());
-                }
+                LibCtruError(unsafe { ctru_sys::socInit(soc_mem, num_bytes as u32) })?;
 
                 Ok(())
             },

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use std::net::Ipv4Addr;
 use std::sync::Mutex;
 
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 use crate::services::ServiceReference;
 use crate::Error;
 
@@ -39,7 +39,7 @@ impl Soc {
             false,
             || {
                 let soc_mem = unsafe { memalign(0x1000, num_bytes) } as *mut u32;
-                LibCtruResult(unsafe { ctru_sys::socInit(soc_mem, num_bytes as u32) })?;
+                ResultCode(unsafe { ctru_sys::socInit(soc_mem, num_bytes as u32) })?;
 
                 Ok(())
             },

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use std::net::Ipv4Addr;
 use std::sync::Mutex;
 
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 use crate::services::ServiceReference;
 use crate::Error;
 
@@ -39,7 +39,7 @@ impl Soc {
             false,
             || {
                 let soc_mem = unsafe { memalign(0x1000, num_bytes) } as *mut u32;
-                LibCtruError(unsafe { ctru_sys::socInit(soc_mem, num_bytes as u32) })?;
+                LibCtruResult(unsafe { ctru_sys::socInit(soc_mem, num_bytes as u32) })?;
 
                 Ok(())
             },

--- a/ctru-rs/src/services/sslc.rs
+++ b/ctru-rs/src/services/sslc.rs
@@ -1,6 +1,6 @@
 // TODO: Implement remaining functions
 
-use crate::error::LibCtruError;
+use crate::error::LibCtruResult;
 
 pub struct SslC(());
 
@@ -8,7 +8,7 @@ impl SslC {
     /// Initialize sslc
     pub fn init() -> crate::Result<Self> {
         unsafe {
-            LibCtruError(ctru_sys::sslcInit(0))?;
+            LibCtruResult(ctru_sys::sslcInit(0))?;
             Ok(SslC(()))
         }
     }
@@ -16,7 +16,7 @@ impl SslC {
     /// Fill `buf` with `buf.len()` random bytes
     pub fn generate_random_data(&self, buf: &mut [u8]) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::sslcGenerateRandomData(
+            LibCtruResult(ctru_sys::sslcGenerateRandomData(
                 buf.as_ptr() as _,
                 buf.len() as u32,
             ))?;

--- a/ctru-rs/src/services/sslc.rs
+++ b/ctru-rs/src/services/sslc.rs
@@ -1,29 +1,23 @@
 // TODO: Implement remaining functions
 
+use crate::error::LibCtruError;
+
 pub struct SslC(());
 
 impl SslC {
     /// Initialize sslc
     pub fn init() -> crate::Result<Self> {
         unsafe {
-            let r = ctru_sys::sslcInit(0);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(SslC(()))
-            }
+            LibCtruError(ctru_sys::sslcInit(0))?;
+            Ok(SslC(()))
         }
     }
 
     /// Fill `buf` with `buf.len()` random bytes
     pub fn generate_random_data(&self, buf: &mut [u8]) -> crate::Result<()> {
         unsafe {
-            let r = ctru_sys::sslcGenerateRandomData(buf.as_ptr() as _, buf.len() as u32);
-            if r < 0 {
-                Err(r.into())
-            } else {
-                Ok(())
-            }
+            LibCtruError(ctru_sys::sslcGenerateRandomData(buf.as_ptr() as _, buf.len() as u32))?;
+            Ok(())
         }
     }
 }

--- a/ctru-rs/src/services/sslc.rs
+++ b/ctru-rs/src/services/sslc.rs
@@ -16,7 +16,10 @@ impl SslC {
     /// Fill `buf` with `buf.len()` random bytes
     pub fn generate_random_data(&self, buf: &mut [u8]) -> crate::Result<()> {
         unsafe {
-            LibCtruError(ctru_sys::sslcGenerateRandomData(buf.as_ptr() as _, buf.len() as u32))?;
+            LibCtruError(ctru_sys::sslcGenerateRandomData(
+                buf.as_ptr() as _,
+                buf.len() as u32,
+            ))?;
             Ok(())
         }
     }

--- a/ctru-rs/src/services/sslc.rs
+++ b/ctru-rs/src/services/sslc.rs
@@ -1,6 +1,6 @@
 // TODO: Implement remaining functions
 
-use crate::error::LibCtruResult;
+use crate::error::ResultCode;
 
 pub struct SslC(());
 
@@ -8,7 +8,7 @@ impl SslC {
     /// Initialize sslc
     pub fn init() -> crate::Result<Self> {
         unsafe {
-            LibCtruResult(ctru_sys::sslcInit(0))?;
+            ResultCode(ctru_sys::sslcInit(0))?;
             Ok(SslC(()))
         }
     }
@@ -16,7 +16,7 @@ impl SslC {
     /// Fill `buf` with `buf.len()` random bytes
     pub fn generate_random_data(&self, buf: &mut [u8]) -> crate::Result<()> {
         unsafe {
-            LibCtruResult(ctru_sys::sslcGenerateRandomData(
+            ResultCode(ctru_sys::sslcGenerateRandomData(
                 buf.as_ptr() as _,
                 buf.len() as u32,
             ))?;


### PR DESCRIPTION
Right now, most calls to ``ctru_sys`` functions look like this:
```rs
let r = ctru_sys::aptInit();
if r < 0 {
    Err(r.into())
} else {
    Ok(Apt(()))
}
```

This PR adds the ``LibCtruResult`` struct (though the name can be changed), which implements the ``Try`` trait to allow the usage of the ``?`` operator. The example above now looks like this:
```rs
LibCtruResult(ctru_sys::appInit())?;
Ok(Apt(()))
```

This makes the code much more simpler, and both do exactly the same thing as it can be seen [here](https://github.com/Techie-Pi/ctru-rs-meziu/blob/28cb72addd2b9836df4e56ceeae416f734d83703/ctru-rs/src/error.rs#L23).

This could be implemented in a macro, but putting the ``i32`` returned from the ``ctru_sys`` functions into a struct defined by the crate allows the future implementation of further abstractions around the _raw_ errors provided by ``ctru_sys`` to cover cases [that can't be covered right now](https://github.com/Techie-Pi/ctru-rs-meziu/blob/28cb72addd2b9836df4e56ceeae416f734d83703/ctru-rs/src/services/fs.rs#L396).

CI is failing due to [this cam function](https://github.com/Techie-Pi/ctru-rs-meziu/blob/28cb72addd2b9836df4e56ceeae416f734d83703/ctru-rs/src/services/cam.rs#L278) not being used (maybe it was meant to be public?, @SteveCookTU)