### PR TITLE
Update manifest with current repo links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["ctru-rs", "ctru-sys", "ctru-sys/docstring-to-rustdoc"]
 
-[patch.'https://github.com/Meziu/ctru-rs']
+[patch.'https://github.com/rust3ds/ctru-rs']
 # Make sure all dependencies use the local ctru-sys package
 ctru-sys = { path = "ctru-sys" }

--- a/README.md
+++ b/README.md
@@ -37,4 +37,3 @@ applies to every file in the tree, unless otherwise noted.
 Rust is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0), with portions covered by various BSD-like licenses.
 
 See [LICENSE-APACHE](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE), [LICENSE-MIT](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT), and [COPYRIGHT](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) for details.
-

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -14,8 +14,8 @@ name = "ctru"
 cfg-if = "1.0"
 ctru-sys = { path = "../ctru-sys", version = "0.4" }
 const-zero = "0.1.0"
-linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
-pthread-3ds = { git = "https://github.com/Meziu/pthread-3ds.git" }
+linker-fix-3ds = { git = "https://github.com/rust3ds/rust-linker-fix-3ds.git" }
+pthread-3ds = { git = "https://github.com/rust3ds/pthread-3ds.git" }
 libc = "0.2.121"
 bitflags = "1.0.0"
 widestring = "0.2.2"


### PR DESCRIPTION
Simple PR to change the repository links to `rust3ds` links.

Links in `rust-linker-fix-3ds` and `pthread-3ds` have already been changed.