### PR TITLE
Default to warn in CI and fix up test runner build on latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
+      # https://github.com/nektos/act/issues/917#issuecomment-1074421318
+      - if: ${{ env.ACT }}
+        name: Hack container for local development
+        run: |
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+
       - name: Checkout branch
         uses: actions/checkout@v2
 
@@ -56,9 +63,10 @@ jobs:
 
       - name: Cargo check
         run: cargo 3ds clippy --color=always --workspace --verbose --all-targets
-        env:
-          RUSTFLAGS:
-            --deny=warnings
+        # --deny=warnings would be nice, but can easily break CI for new clippy
+        # lints getting added. I'd also like to use Github's "inline warnings"
+        # feature, but https://github.com/actions/runner/issues/2341 means we
+        # can't have both that *and* colored output.
 
   # TODO: it would be nice to actually build 3dsx for examples/tests, etc.
   # and run it somehow, but exactly how remains to be seen.

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -5,6 +5,7 @@ license = "https://en.wikipedia.org/wiki/Zlib_License"
 name = "ctru-rs"
 version = "0.7.1"
 edition = "2021"
+rust-version = "1.64"
 
 [lib]
 crate-type = ["rlib"]

--- a/ctru-rs/src/test_runner.rs
+++ b/ctru-rs/src/test_runner.rs
@@ -4,7 +4,7 @@ extern crate test;
 
 use std::io;
 
-use test::{ColorConfig, Options, OutputFormat, RunIgnored, TestDescAndFn, TestFn, TestOpts};
+use test::{ColorConfig, OutputFormat, TestDescAndFn, TestFn, TestOpts};
 
 use crate::console::Console;
 use crate::gfx::Gfx;
@@ -25,34 +25,18 @@ pub(crate) fn run(tests: &[&TestDescAndFn]) {
     top_screen.set_wide_mode(true);
     let _console = Console::init(top_screen);
 
-    // TODO: it would be nice to have a way of specifying argv to make these
-    // configurable at runtime, but I can't figure out how to do it easily,
-    //  so for now, just hardcode everything.
     let opts = TestOpts {
-        list: false,
-        filters: Vec::new(),
-        filter_exact: false,
-        // Forking is not supported
         force_run_in_process: true,
-        exclude_should_panic: false,
-        run_ignored: RunIgnored::No,
         run_tests: true,
-        // Don't run benchmarks. We may want to create a separate runner for them in the future
-        bench_benchmarks: false,
-        logfile: None,
-        nocapture: false,
         // TODO: color doesn't work because of TERM/TERMINFO.
         // With RomFS we might be able to fake this out nicely...
         color: ColorConfig::AutoColor,
         format: OutputFormat::Pretty,
-        shuffle: false,
-        shuffle_seed: None,
-        test_threads: None,
-        skip: Vec::new(),
-        time_options: None,
-        options: Options::new(),
+        // Hopefully this interface is more stable vs specifying individual options,
+        // and parsing the empty list of args should always work, I think.
+        // TODO Ideally we could pass actual std::env::args() here too
+        ..test::test::parse_opts(&[]).unwrap().unwrap()
     };
-
     // Use the default test implementation with our hardcoded options
     let _success = run_static_tests(&opts, tests).unwrap();
 

--- a/ctru-sys/build.rs
+++ b/ctru-sys/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=DEVKITPRO");
-    println!("cargo:rustc-link-search=native={}/libctru/lib", dkp_path);
+    println!("cargo:rustc-link-search=native={dkp_path}/libctru/lib");
     println!(
         "cargo:rustc-link-lib=static={}",
         match profile.as_str() {


### PR DESCRIPTION
Do some minor fixes based on @Meziu comment: https://github.com/rust3ds/ctru-rs/pull/83#issuecomment-1373469738

- Add a helper for local testing with https://github.com/nektos/act
- Don't deny clippy warnings, they can change too easily and break CI
- Add minimum rust version just for completeness' sake