### PR TITLE
fix dependency build issue

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -13,7 +13,7 @@ name = "ctru"
 
 [dependencies]
 cfg-if = "1.0"
-ctru-sys = { path = "../ctru-sys", version = "0.4" }
+ctru-sys = { git = "https://github.com/rust3ds/ctru-rs.git", version = "0.4" }
 const-zero = "0.1.0"
 linker-fix-3ds = { git = "https://github.com/rust3ds/rust-linker-fix-3ds.git" }
 pthread-3ds = { git = "https://github.com/rust3ds/pthread-3ds.git" }


### PR DESCRIPTION
Fixes #88 

Tested by making forks of `ctru-rs`, `pthread-3ds` and `rust-linker-fix-3ds`.

With this change, making a new project and adding just this to the `Config.toml` should make the project build (provided the environment is set up properly, of course)

```toml
[dependencies]
ctru-rs = { git = "https://github.com/rust3ds/ctru-rs.git" }
```