### PR TITLE
Fix non-working example and improve the camera module

### DIFF
--- a/ctru-rs/examples/camera-image.rs
+++ b/ctru-rs/examples/camera-image.rs
@@ -56,7 +56,7 @@ fn main() {
             .expect("Failed to disable trimming");
     }
 
-    let mut buf = vec![0; BUF_SIZE];
+    let mut buf = vec![0u8; BUF_SIZE];
 
     println!("\nPress R to take a new picture");
     println!("Press Start to exit to Homebrew Launcher");

--- a/ctru-rs/examples/camera-image.rs
+++ b/ctru-rs/examples/camera-image.rs
@@ -119,9 +119,10 @@ fn rotate_image_to_screen(src: &[u8], framebuf: *mut u8, width: usize, height: u
             let draw_index = (draw_x * height + draw_y) * 2; // This 2 stands for the number of bytes per pixel (16 bits)
 
             unsafe {
+                // We'll work with pointers since the frambuffer is a raw pointer regardless.
+                // The offsets are completely safe as long as the width and height are correct.
                 let pixel_pointer = framebuf.offset(draw_index as isize);
-                *pixel_pointer = src[read_index];
-                *pixel_pointer.offset(1) = src[read_index + 1];
+                pixel_pointer.copy_from(src.as_ptr().offset(read_index as isize), 2);
             }
         }
     }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -55,6 +55,8 @@ pub enum Error {
     Libc(String),
     ServiceAlreadyActive,
     OutputAlreadyRedirected,
+    /// The first member is the length of the buffer provided by the user, the second parameter is the size of the requested data (in bytes).
+    BufferTooShort(usize, usize),
 }
 
 impl Error {
@@ -101,6 +103,7 @@ impl fmt::Debug for Error {
             Self::Libc(err) => f.debug_tuple("Libc").field(err).finish(),
             Self::ServiceAlreadyActive => f.debug_tuple("ServiceAlreadyActive").finish(),
             Self::OutputAlreadyRedirected => f.debug_tuple("OutputAlreadyRedirected").finish(),
+            Self::BufferTooShort(provided, wanted) => f.debug_tuple("BufferTooShort").field(provided).field(wanted).finish(),
         }
     }
 }
@@ -110,7 +113,7 @@ impl fmt::Display for Error {
         match self {
             &Self::Os(err) => write!(
                 f,
-                "libctru result code 0x{err:08X}: [{} {}] {}: {}",
+                "Libctru result code 0x{err:08X}: [{} {}] {}: {}",
                 result_code_level_str(err),
                 result_code_module_str(err),
                 result_code_summary_str(err),
@@ -119,8 +122,9 @@ impl fmt::Display for Error {
             Self::Libc(err) => write!(f, "{err}"),
             Self::ServiceAlreadyActive => write!(f, "Service already active"),
             Self::OutputAlreadyRedirected => {
-                write!(f, "output streams are already redirected to 3dslink")
+                write!(f, "Output streams are already redirected to 3dslink")
             }
+            Self::BufferTooShort(provided, wanted) => write!(f, "The provided buffer's length is too short (length = {provided}) to hold the wanted data (size = {wanted})")
         }
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -104,9 +104,9 @@ impl fmt::Debug for Error {
             Self::ServiceAlreadyActive => f.debug_tuple("ServiceAlreadyActive").finish(),
             Self::OutputAlreadyRedirected => f.debug_tuple("OutputAlreadyRedirected").finish(),
             Self::BufferTooShort(provided, wanted) => f
-                .debug_tuple("BufferTooShort")
-                .field(provided)
-                .field(wanted)
+                .debug_struct("BufferTooShort")
+                .field("provided", provided)
+                .field("wanted", wanted)
                 .finish(),
         }
     }
@@ -117,18 +117,18 @@ impl fmt::Display for Error {
         match self {
             &Self::Os(err) => write!(
                 f,
-                "Libctru result code 0x{err:08X}: [{} {}] {}: {}",
+                "libctru result code 0x{err:08X}: [{} {}] {}: {}",
                 result_code_level_str(err),
                 result_code_module_str(err),
                 result_code_summary_str(err),
                 result_code_description_str(err)
             ),
             Self::Libc(err) => write!(f, "{err}"),
-            Self::ServiceAlreadyActive => write!(f, "Service already active"),
+            Self::ServiceAlreadyActive => write!(f, "service already active"),
             Self::OutputAlreadyRedirected => {
-                write!(f, "Output streams are already redirected to 3dslink")
+                write!(f, "output streams are already redirected to 3dslink")
             }
-            Self::BufferTooShort(provided, wanted) => write!(f, "The provided buffer's length is too short (length = {provided}) to hold the wanted data (size = {wanted})")
+            Self::BufferTooShort(provided, wanted) => write!(f, "the provided buffer's length is too short (length = {provided}) to hold the wanted data (size = {wanted})")
         }
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -103,7 +103,11 @@ impl fmt::Debug for Error {
             Self::Libc(err) => f.debug_tuple("Libc").field(err).finish(),
             Self::ServiceAlreadyActive => f.debug_tuple("ServiceAlreadyActive").finish(),
             Self::OutputAlreadyRedirected => f.debug_tuple("OutputAlreadyRedirected").finish(),
-            Self::BufferTooShort(provided, wanted) => f.debug_tuple("BufferTooShort").field(provided).field(wanted).finish(),
+            Self::BufferTooShort(provided, wanted) => f
+                .debug_tuple("BufferTooShort")
+                .field(provided)
+                .field(wanted)
+                .finish(),
         }
     }
 }

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -776,7 +776,7 @@ pub trait Camera {
             ));
 
             // We close everything first, then we check for possible errors
-            ResultCode(ctru_sys::svcCloseHandle(receive_event));
+            let _ = ctru_sys::svcCloseHandle(receive_event); // We wouldn't return the error even if there was one, so no use of ResultCode is needed
             ResultCode(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
             ResultCode(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
 

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -731,7 +731,7 @@ pub trait Camera {
             Ok::<u32, i32>(buf_size)
         }?;
 
-        let screen_size = u32::from(width) * u32::from(width) * 2;
+        let screen_size = u32::from(width) * u32::from(height) * 2;
 
         let mut buf = vec![0u8; usize::try_from(screen_size).unwrap()];
 

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -742,8 +742,8 @@ pub trait Camera {
         };
 
         let screen_size: usize = usize::from(width) * usize::from(height) * 2;
-        if buffer.len() < screen_size as usize {
-            return Err(Error::BufferTooShort(buffer.len(), screen_size))
+        if buffer.len() < screen_size {
+            return Err(Error::BufferTooShort(buffer.len(), screen_size));
         }
 
         unsafe {

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -317,10 +317,10 @@ impl AudioFormat {
 impl fmt::Display for NdspError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::InvalidChannel(id) => write!(f, "Audio Channel with ID {id} doesn't exist. Valid channels have an ID between 0 and 23."),
-            Self::ChannelAlreadyInUse(id) => write!(f, "Audio Channel with ID {id} is already being used. Drop the other instance if you want to use it here."),
-            Self::WaveBusy(id) => write!(f, "The selected WaveInfo is busy playing on channel {id}."),
-            Self::SampleCountOutOfBounds(samples_requested, max_samples) => write!(f, "The sample count requested is too big. Requested amount was {samples_requested} while the maximum sample count is {max_samples}."),
+            Self::InvalidChannel(id) => write!(f, "audio Channel with ID {id} doesn't exist. Valid channels have an ID between 0 and 23"),
+            Self::ChannelAlreadyInUse(id) => write!(f, "audio Channel with ID {id} is already being used. Drop the other instance if you want to use it here"),
+            Self::WaveBusy(id) => write!(f, "the selected WaveInfo is busy playing on channel {id}"),
+            Self::SampleCountOutOfBounds(samples_requested, max_samples) => write!(f, "the sample count requested is too big (requested = {samples_requested}, maximum = {max_samples})"),
         }
     }
 }


### PR DESCRIPTION
The camera-image example didn't work (it was just a typo in the timeout wait). I took the chance to improve performance and catch some errors.

Changes:
- No more conversion from RGB565 to RGB8 (now we only rotate the image directly to the framebuffer).
- The example now only flushes the image once it gets shot, and not every frame (CPU rendering created a lot of latency).
- Removed all needless allocations. We allocated around 384000 bytes _**each time**_ a photo was shot. Now we allocate only once at the start.
- The `svc` timeout wasn't considered an error (it took me some time to debug it). We should probably handle those cases in a separate `svc` module PR (which we were already talking about), but for now it correctly returns the error.
- I've also documented some edge cases that cause ARM exceptions when using `svc`, it was a learning experience!

Tell me what you think 😄 