### PR TITLE
Add a basic AM service wrapper and an example that uses it

### DIFF
--- a/ctru-rs/examples/title-info.rs
+++ b/ctru-rs/examples/title-info.rs
@@ -59,18 +59,18 @@ fn main() {
         }
 
         if refresh {
-            let mut selected_title = 0;
+            let mut selected_title = cur_list.iter().skip(offset).next().unwrap();
             // Clear top screen and write title ids to it
             top_screen.select();
             print!("\x1b[2J");
 
             // Top screen seems to have only 30 rows
-            for (i, id) in cur_list.iter().skip(offset).take(29).enumerate() {
+            for (i, title) in cur_list.iter().skip(offset).take(29).enumerate() {
                 if i == 0 {
-                    selected_title = *id;
-                    println!("=> {id:x}");
+                    selected_title = title;
+                    println!("=> {:x}", title.id());
                 } else {
-                    println!("   {id:x}");
+                    println!("   {:x}", title.id());
                 }
             }
 
@@ -79,20 +79,18 @@ fn main() {
             println!("\x1b[2J");
             // Move cursor to top left
             println!("\x1b[1;1");
-            let media = if use_nand {
-                FsMediaType::Nand
-            } else {
-                FsMediaType::Sd
-            };
-            match am.get_title_info(media, &mut [selected_title]) {
+
+            match selected_title.get_title_info() {
                 Ok(info) => {
-                    // Vec returned by Am::get_title_info always has same length as inputed slice
-                    let info = info[0];
                     println!("Size: {} KB", info.size_bytes() / 1024);
                     println!("Version: 0x{:x}", info.version());
                     println!("Type: 0x{:x}", info.type_());
                 }
                 Err(e) => println!("Failed to get title info: {}", e),
+            }
+            match selected_title.get_product_code() {
+                Ok(code) => println!("Product code: \"{code}\""),
+                Err(e) => println!("Failed to get product code: {}", e),
             }
 
             println!("\x1b[26;0HPress START to exit");

--- a/ctru-rs/examples/title-info.rs
+++ b/ctru-rs/examples/title-info.rs
@@ -9,19 +9,26 @@ fn main() {
     let hid = Hid::init().expect("Couldn't obtain HID controller");
     let apt = Apt::init().expect("Couldn't obtain APT controller");
     let am = Am::init().expect("Couldn't obtain AM controller");
-    let _console = Console::init(gfx.top_screen.borrow_mut());
+    let top_screen = Console::init(gfx.top_screen.borrow_mut());
+    let bottom_screen = Console::init(gfx.bottom_screen.borrow_mut());
 
-    let title_count = am
+    let sd_count = am
         .get_title_count(FsMediaType::Sd)
-        .expect("Failed to get title count");
-    println!("This 3DS has {title_count} titles on its SD Card:");
-
-    let title_list = am
+        .expect("Failed to get sd title count");
+    let sd_list = am
         .get_title_list(FsMediaType::Sd)
-        .expect("Failed to get title list");
-    for id in title_list {
-        println!("{id:x}");
-    }
+        .expect("Failed to get sd title list");
+
+    let nand_count = am
+        .get_title_count(FsMediaType::Nand)
+        .expect("Failed to get nand title count");
+    let nand_list = am
+        .get_title_list(FsMediaType::Nand)
+        .expect("Failed to get nand title list");
+
+    let mut offset = 0;
+    let mut refresh = true;
+    let mut use_nand = false;
 
     // Main loop
     while apt.main_loop() {
@@ -31,6 +38,77 @@ fn main() {
         if hid.keys_down().contains(KeyPad::KEY_START) {
             break;
         }
+        if hid.keys_down().contains(KeyPad::KEY_SELECT) {
+            refresh = true;
+            offset = 0;
+            use_nand = !use_nand;
+        }
+
+        let cur_list = if use_nand { &nand_list } else { &sd_list };
+
+        if hid.keys_down().intersects(KeyPad::KEY_DOWN) {
+            if offset + 1 < cur_list.len() {
+                offset = offset + 1;
+                refresh = true;
+            }
+        } else if hid.keys_down().intersects(KeyPad::KEY_UP) {
+            if offset > 0 {
+                offset = offset - 1;
+                refresh = true;
+            }
+        }
+
+        if refresh {
+            let mut selected_title = 0;
+            // Clear top screen and write title ids to it
+            top_screen.select();
+            print!("\x1b[2J");
+
+            // Top screen seems to have only 30 rows
+            for (i, id) in cur_list.iter().skip(offset).take(29).enumerate() {
+                if i == 0 {
+                    selected_title = *id;
+                    println!("=> {id:x}");
+                } else {
+                    println!("   {id:x}");
+                }
+            }
+
+            // Clear bottom screen and write properties of selected title to it
+            bottom_screen.select();
+            println!("\x1b[2J");
+            // Move cursor to top left
+            println!("\x1b[1;1");
+            let media = if use_nand {
+                FsMediaType::Nand
+            } else {
+                FsMediaType::Sd
+            };
+            match am.get_title_info(media, &mut [selected_title]) {
+                Ok(info) => {
+                    // Vec returned by Am::get_title_info always has same length as inputed slice
+                    let info = info[0];
+                    println!("Size: {} KB", info.size_bytes() / 1024);
+                    println!("Version: 0x{:x}", info.version());
+                    println!("Type: 0x{:x}", info.type_());
+                }
+                Err(e) => println!("Failed to get title info: {}", e),
+            }
+
+            println!("\x1b[26;0HPress START to exit");
+            if use_nand {
+                println!("Press SELECT to choose SD Card");
+                println!("Current medium: NAND");
+                println!("Title count: {}", nand_count);
+            } else {
+                println!("Press SELECT to choose NAND");
+                println!("Current medium: SD Card");
+                println!("Title count: {}", sd_count);
+            }
+
+            refresh = false;
+        }
+
         // Flush and swap framebuffers
         gfx.flush_buffers();
         gfx.swap_buffers();

--- a/ctru-rs/examples/title-info.rs
+++ b/ctru-rs/examples/title-info.rs
@@ -84,7 +84,6 @@ fn main() {
                 Ok(info) => {
                     println!("Size: {} KB", info.size_bytes() / 1024);
                     println!("Version: 0x{:x}", info.version());
-                    println!("Type: 0x{:x}", info.type_());
                 }
                 Err(e) => println!("Failed to get title info: {}", e),
             }

--- a/ctru-rs/examples/title-info.rs
+++ b/ctru-rs/examples/title-info.rs
@@ -11,10 +11,14 @@ fn main() {
     let am = Am::init().expect("Couldn't obtain AM controller");
     let _console = Console::init(gfx.top_screen.borrow_mut());
 
-    let title_count = am.get_title_count(FsMediaType::Sd).expect("Failed to get title count");
+    let title_count = am
+        .get_title_count(FsMediaType::Sd)
+        .expect("Failed to get title count");
     println!("This 3DS has {title_count} titles on its SD Card:");
 
-    let title_list = am.get_title_list(FsMediaType::Sd).expect("Failed to get title list");
+    let title_list = am
+        .get_title_list(FsMediaType::Sd)
+        .expect("Failed to get title list");
     for id in title_list {
         println!("{id:x}");
     }

--- a/ctru-rs/examples/title-info.rs
+++ b/ctru-rs/examples/title-info.rs
@@ -1,0 +1,37 @@
+use ctru::prelude::*;
+use ctru::services::am::Am;
+use ctru::services::fs::FsMediaType;
+
+fn main() {
+    ctru::use_panic_handler();
+
+    let gfx = Gfx::init().expect("Couldn't obtain GFX controller");
+    let hid = Hid::init().expect("Couldn't obtain HID controller");
+    let apt = Apt::init().expect("Couldn't obtain APT controller");
+    let am = Am::init().expect("Couldn't obtain AM controller");
+    let _console = Console::init(gfx.top_screen.borrow_mut());
+
+    let title_count = am.get_title_count(FsMediaType::Sd).expect("Failed to get title count");
+    println!("This 3DS has {title_count} titles on its SD Card:");
+
+    let title_list = am.get_title_list(FsMediaType::Sd).expect("Failed to get title list");
+    for id in title_list {
+        println!("{id:x}");
+    }
+
+    // Main loop
+    while apt.main_loop() {
+        //Scan all the inputs. This should be done once for each frame
+        hid.scan_input();
+
+        if hid.keys_down().contains(KeyPad::KEY_START) {
+            break;
+        }
+        // Flush and swap framebuffers
+        gfx.flush_buffers();
+        gfx.swap_buffers();
+
+        //Wait for VBlank
+        gfx.wait_for_vblank();
+    }
+}

--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -4,30 +4,17 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
 #[derive(Copy, Clone, Debug)]
-#[repr(C)]
-pub struct TitleInfo {
-    id: u64,
-    size: u64,
-    version: u16,
-    pad: u16,
-    type_: u32,
-}
-
-// Make sure TitleInfo is correct size
-const _TITLEINFO_SIZE_CHECK: [u8; 0x18] = [0; std::mem::size_of::<TitleInfo>()];
-
+#[repr(transparent)]
+pub struct TitleInfo(ctru_sys::AM_TitleEntry);
 impl TitleInfo {
     pub fn id(&self) -> u64 {
-        self.id
+        self.0.titleID
     }
     pub fn size_bytes(&self) -> u64 {
-        self.size
+        self.0.size
     }
     pub fn version(&self) -> u16 {
-        self.version
-    }
-    pub fn type_(&self) -> u32 {
-        self.type_
+        self.0.version
     }
 }
 

--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -1,0 +1,43 @@
+use crate::error::ResultCode;
+use crate::services::fs::FsMediaType;
+
+pub struct Am(());
+
+impl Am {
+    pub fn init() -> crate::Result<Am> {
+        unsafe {
+            ResultCode(ctru_sys::amInit())?;
+            Ok(Am(()))
+        }
+    }
+
+    pub fn get_title_count(&self, mediatype: FsMediaType) -> crate::Result<u32> {
+        unsafe {
+            let mut count = 0;
+            ResultCode(ctru_sys::AM_GetTitleCount(mediatype as u32, &mut count))?;
+            Ok(count)
+        }
+    }
+
+    pub fn get_title_list(&self, mediatype: FsMediaType) -> crate::Result<Vec<u64>> {
+        unsafe {
+            let count = self.get_title_count(mediatype)?;
+            let mut buf = Vec::with_capacity(count as usize);
+            let mut read_amount = 0;
+            ResultCode(ctru_sys::AM_GetTitleList(
+                &mut read_amount,
+                mediatype as u32,
+                count,
+                buf.as_mut_ptr(),
+            ))?;
+            buf.set_len(read_amount as usize);
+            Ok(buf)
+        }
+    }
+}
+
+impl Drop for Am {
+    fn drop(&mut self) {
+        unsafe { ctru_sys::amExit() };
+    }
+}

--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -78,7 +78,7 @@ impl Am {
 
     pub fn get_title_list(&self, mediatype: FsMediaType) -> crate::Result<Vec<Title>> {
         let count = self.get_title_count(mediatype)?;
-        let mut buf = Vec::with_capacity(count as usize);
+        let mut buf = vec![0; count as usize];
         let mut read_amount = 0;
         unsafe {
             ResultCode(ctru_sys::AM_GetTitleList(
@@ -87,8 +87,6 @@ impl Am {
                 count,
                 buf.as_mut_ptr(),
             ))?;
-
-            buf.set_len(read_amount as usize);
         }
         Ok(buf
             .into_iter()

--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -24,12 +24,14 @@ impl Am {
             let count = self.get_title_count(mediatype)?;
             let mut buf = Vec::with_capacity(count as usize);
             let mut read_amount = 0;
+
             ResultCode(ctru_sys::AM_GetTitleList(
                 &mut read_amount,
                 mediatype as u32,
                 count,
                 buf.as_mut_ptr(),
             ))?;
+
             buf.set_len(read_amount as usize);
             Ok(buf)
         }

--- a/ctru-rs/src/services/fs.rs
+++ b/ctru-rs/src/services/fs.rs
@@ -44,6 +44,14 @@ bitflags! {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[repr(u32)]
+pub enum FsMediaType {
+    Nand = ctru_sys::MEDIATYPE_NAND,
+    Sd = ctru_sys::MEDIATYPE_SD,
+    GameCard = ctru_sys::MEDIATYPE_GAME_CARD,
+}
+
+#[derive(Copy, Clone, Debug)]
 pub enum PathType {
     Invalid,
     Empty,

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -5,8 +5,8 @@
 //!
 //! Some include: button input, audio playback, graphics rendering, built-in cameras, etc.
 
-pub mod apt;
 pub mod am;
+pub mod apt;
 pub mod cam;
 pub mod cfgu;
 pub mod fs;

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -6,6 +6,7 @@
 //! Some include: button input, audio playback, graphics rendering, built-in cameras, etc.
 
 pub mod apt;
+pub mod am;
 pub mod cam;
 pub mod cfgu;
 pub mod fs;


### PR DESCRIPTION
This PR adds basic AM wrapper, for use by programs that read title data, and a basic example.
I was unsure where to put FsMediaType enum, initially it was in am.rs, but in libctru it was defined in fs.h, so it went into fs.rs
I'm also unsure about the prelude, whether Am struct and FsMediaType enum should be added to it.
As it usually makes sense to get all titles installed, instead of random n of them, get_title_list returns a Vec of all title ids on a given FsMediaType.
Should TitleId be a newtype or struct so that it could have some helper methods like TitleId::upper() etc?

This PR was tested with the 'title-info' example on a New 3DS with Luma3DS v11.0 and system firmware v11.16.0-49E