### PR TITLE
Add Smdh struct

### DIFF
--- a/ctru-rs/examples/title-info.rs
+++ b/ctru-rs/examples/title-info.rs
@@ -1,5 +1,6 @@
 use ctru::prelude::*;
 use ctru::services::am::Am;
+use ctru::services::cfgu::Cfgu;
 use ctru::services::fs::FsMediaType;
 
 fn main() {
@@ -9,8 +10,11 @@ fn main() {
     let hid = Hid::init().expect("Couldn't obtain HID controller");
     let apt = Apt::init().expect("Couldn't obtain APT controller");
     let am = Am::init().expect("Couldn't obtain AM controller");
+    let cfgu = Cfgu::init().expect("Couldn't obtain CFGU controller");
     let top_screen = Console::init(gfx.top_screen.borrow_mut());
     let bottom_screen = Console::init(gfx.bottom_screen.borrow_mut());
+
+    let system_lang = cfgu.get_language().expect("Failed to get system language");
 
     let sd_count = am
         .get_title_count(FsMediaType::Sd)
@@ -90,6 +94,15 @@ fn main() {
             match selected_title.get_product_code() {
                 Ok(code) => println!("Product code: \"{code}\""),
                 Err(e) => println!("Failed to get product code: {}", e),
+            }
+            match selected_title.get_smdh() {
+                Ok(smdh) => {
+                    println!("Name: {}", smdh.short_name(system_lang));
+                    println!("Publisher: {}", smdh.publisher(system_lang));
+                    println!("Flags: {:?}", smdh.flags());
+                    println!("Region: {:?}", smdh.region());
+                }
+                Err(e) => println!("Failed to open SMDH: {e}"),
             }
 
             println!("\x1b[26;0HPress START to exit");

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -67,6 +67,7 @@ pub mod linear;
 pub mod mii;
 pub mod prelude;
 pub mod services;
+pub mod smdh;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "romfs", romfs_exists))] {

--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -74,7 +74,7 @@ impl<'a> Title<'a> {
         let archive_path_data: [u32; 4] = [
             self.low_u32(),
             self.high_u32(),
-            self.media_type() as u32,
+            self.mediatype as u32,
             0x0,
         ];
         let smdh_path_data: [u32; 5] = [0x0, 0x0, 0x2, u32::from_le_bytes(*b"icon"), 0x0];

--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -71,12 +71,8 @@ impl<'a> Title<'a> {
 
     pub fn get_smdh(&self) -> crate::Result<Smdh> {
         // i have no idea how to make this look better
-        let archive_path_data: [u32; 4] = [
-            self.low_u32(),
-            self.high_u32(),
-            self.mediatype as u32,
-            0x0,
-        ];
+        let archive_path_data: [u32; 4] =
+            [self.low_u32(), self.high_u32(), self.mediatype as u32, 0x0];
         let smdh_path_data: [u32; 5] = [0x0, 0x0, 0x2, u32::from_le_bytes(*b"icon"), 0x0];
 
         let archive_path = ctru_sys::FS_Path {

--- a/ctru-rs/src/smdh.rs
+++ b/ctru-rs/src/smdh.rs
@@ -1,0 +1,99 @@
+use crate::services::cfgu::Language;
+use bitflags::bitflags;
+
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct Smdh {
+    magic: [u8; 4],
+    version: u16,
+    titles: [SmdhTitle; 16],
+    age_ratings: [u8; 16],
+    region_lock: RegionLock,
+    matchmaker_id: u32,
+    matchmaker_bit_id: u64,
+    flags: SmdhFlags,
+    eula_version_major: u8,
+    eula_version_minor: u8,
+    optimal_banner_anim_frame: f32,
+    streetpass_id: u32,
+    _pad: [u8; 8],
+    small_icon: [u8; 0x480],
+    large_icon: [u8; 0x1200],
+}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct SmdhTitle {
+    short: [u16; 0x40],
+    long: [u16; 0x80],
+    publisher: [u16; 0x40],
+}
+
+bitflags! {
+    #[repr(transparent)]
+    pub struct SmdhFlags: u32 {
+        const VISIBLE = 0x1;
+        const AUTOBOOT_GAMECARD = 0x2;
+        const PARENTAL_3D_ALLOW = 0x4;
+        const REQUIRE_CTR_EULA = 0x8;
+        const AUTOSAVE_ON_EXIT = 0x10;
+        const EXTENDED_BANNER = 0x20;
+        const REGION_RATING_REQUIRED = 0x40;
+        const SAVEDATA_USAGE = 0x80;
+        const RECORD_USAGE = 0x100;
+        const DISABLE_SD_SAVEDATA_BACKUPS = 0x400;
+        const NEW3DS_EXCLUSIVE = 0x1000;
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    pub struct RegionLock: u32 {
+        const JAPAN = 0x1;
+        const NORTH_AMERICA = 0x2;
+        const EUROPE = 0x4;
+        const AUSTRALIA = 0x8;
+        const CHINA = 0x10;
+        const KOREA = 0x20;
+        const TAIWAN = 0x40;
+        const REGION_FREE = 0x7fff_ffff;
+    }
+}
+
+impl Smdh {
+    pub fn short_name(&self, lang: Language) -> String {
+        String::from_utf16_lossy(&self.titles[lang as usize].short)
+    }
+
+    pub fn long_name(&self, lang: Language) -> String {
+        String::from_utf16_lossy(&self.titles[lang as usize].long)
+    }
+
+    pub fn publisher(&self, lang: Language) -> String {
+        String::from_utf16_lossy(&self.titles[lang as usize].publisher)
+    }
+
+    pub fn version(&self) -> u16 {
+        self.version
+    }
+
+    pub fn flags(&self) -> SmdhFlags {
+        self.flags
+    }
+
+    pub fn region(&self) -> RegionLock {
+        self.region_lock
+    }
+
+    pub fn eula_version(&self) -> (u8, u8) {
+        (self.eula_version_major, self.eula_version_minor)
+    }
+
+    pub(crate) fn magic(&self) -> [u8; 4] {
+        self.magic
+    }
+
+    pub fn streetpass_id(&self) -> u32 {
+        self.streetpass_id
+    }
+}


### PR DESCRIPTION
This MR adds Smdh struct to read smdh data from ExeFS of CXI files and some related data, like flags and region lockout data.
I wasn't really sure where to put it, so it went into `src/smdh.rs` and reading it went to `src/services/am.rs` as it's closely related to titles.
I'm not sure what can I do to make the actual-reading of data in `Title::get_smdh` look nicer.
I had an idea to make a somewhat-generic code for reading/writing from/to weird ArchiveIds with custom binary paths but I'm not sure how to implement it. The other part that looks sorta ugly-ish is verifying that smdh's magic data is 'SMDH', as I can't directly access magic field of `Smdh` from `am.rs` and it doesn't really make sense to add a public getter for it, so I added a public-to-crate getter for it.

I used https://www.3dbrew.org/wiki/SMDH and https://github.com/J-D-K/JKSM as references.