### PR TITLE
Improve Ndsp API

### DIFF
--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -32,7 +32,6 @@ pub enum AudioFormat {
 }
 
 /// Representation of volume mix for a channel.
-/// Each member is made up of 2 values, the first is for the "left" channel, while the second is for the "right" channel.
 #[derive(Copy, Clone, Debug)]
 pub struct AudioMix {
     raw: [f32; 12],

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -35,7 +35,7 @@ pub enum AudioFormat {
 /// Each member is made up of 2 values, the first is for the "left" channel, while the second is for the "right" channel.
 #[derive(Copy, Clone, Debug)]
 pub struct AudioMix {
-    raw: [f32;12]
+    raw: [f32; 12],
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -317,9 +317,7 @@ impl AudioFormat {
 impl AudioMix {
     /// Creates a new [AudioMix] with all volumes set to 0.
     pub fn zeroed() -> Self {
-        Self {
-            raw: [0.;12],
-        }
+        Self { raw: [0.; 12] }
     }
 
     /// Returns a reference to the raw data.
@@ -347,10 +345,10 @@ impl AudioMix {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
-    
+
         let index = 4 + id * 4;
 
-        &self.raw[index..index+2]
+        &self.raw[index..index + 2]
     }
 
     /// Returns a reference to the "back" volume mix (left and right channel) for the specified auxiliary output device.
@@ -358,10 +356,10 @@ impl AudioMix {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
-    
+
         let index = 6 + id * 4;
 
-        &self.raw[index..index+2]
+        &self.raw[index..index + 2]
     }
 
     /// Returns a mutable reference to the "front" volume mix (left and right channel).
@@ -379,10 +377,10 @@ impl AudioMix {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
-    
+
         let index = 4 + id * 4;
 
-        &mut self.raw[index..index+2]
+        &mut self.raw[index..index + 2]
     }
 
     /// Returns a mutable reference to the "back" volume mix (left and right channel) for the specified auxiliary output device.
@@ -390,10 +388,10 @@ impl AudioMix {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
-    
+
         let index = 6 + id * 4;
 
-        &mut self.raw[index..index+2]
+        &mut self.raw[index..index + 2]
     }
 }
 
@@ -409,9 +407,7 @@ impl Default for AudioMix {
 
 impl From<[f32; 12]> for AudioMix {
     fn from(value: [f32; 12]) -> Self {
-        Self {
-            raw: value,
-        }
+        Self { raw: value }
     }
 }
 

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -418,7 +418,7 @@ impl AudioMix {
     }
 }
 
-/// Returns an [AudioMix] object with "front left" and "front right" volumes set to max, and all other volumes set to 0.
+/// Returns an [AudioMix] object with "front left" and "front right" volumes set to 100%, and all other volumes set to 0%.
 impl Default for AudioMix {
     fn default() -> Self {
         let mut mix = AudioMix::zeroed();

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -329,68 +329,92 @@ impl AudioMix {
         &mut self.raw
     }
 
-    /// Returns a reference to the "front" volume mix (left and right channel).
-    pub fn front(&self) -> &[f32] {
-        &self.raw[..2]
+    /// Returns the values set for the "front" volume mix (left and right channel).
+    pub fn front(&self) -> (f32, f32) {
+        (self.raw[0], self.raw[1])
     }
 
-    /// Returns a reference to the "back" volume mix (left and right channel).
-    pub fn back(&self) -> &[f32] {
-        &self.raw[2..4]
+    /// Returns the values set for the "back" volume mix (left and right channel).
+    pub fn back(&self) -> (f32, f32) {
+        (self.raw[2], self.raw[3])
     }
 
-    /// Returns a reference to the "front" volume mix (left and right channel) for the specified auxiliary output device.
-    pub fn aux_front(&self, id: usize) -> &[f32] {
+    /// Returns the values set for the "front" volume mix (left and right channel) for the specified auxiliary output device (either 0 or 1).
+    pub fn aux_front(&self, id: usize) -> (f32, f32) {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
 
         let index = 4 + id * 4;
 
-        &self.raw[index..index + 2]
+        (self.raw[index], self.raw[index + 1])
     }
 
-    /// Returns a reference to the "back" volume mix (left and right channel) for the specified auxiliary output device.
-    pub fn aux_back(&self, id: usize) -> &[f32] {
+    /// Returns the values set for the "back" volume mix (left and right channel) for the specified auxiliary output device (either 0 or 1).
+    pub fn aux_back(&self, id: usize) -> (f32, f32) {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
 
         let index = 6 + id * 4;
 
-        &self.raw[index..index + 2]
+        (self.raw[index], self.raw[index + 1])
     }
 
-    /// Returns a mutable reference to the "front" volume mix (left and right channel).
-    pub fn front_mut(&mut self) -> &mut [f32] {
-        &mut self.raw[..2]
+    /// Sets the values for the "front" volume mix (left and right channel).
+    ///
+    /// # Notes
+    ///
+    /// [Channel] will normalize the mix values to be within 0 and 1.
+    /// However, an [AudioMix] instance with larger/smaller values is valid.
+    pub fn set_front(&mut self, left: f32, right: f32) {
+        self.raw[0] = left;
+        self.raw[1] = right;
     }
 
-    /// Returns a mutable reference to the "back" volume mix (left and right channel).
-    pub fn back_mut(&mut self) -> &mut [f32] {
-        &mut self.raw[2..4]
+    /// Sets the values for the "back" volume mix (left and right channel).
+    ///
+    /// # Notes
+    ///
+    /// [Channel] will normalize the mix values to be within 0 and 1.
+    /// However, an [AudioMix] instance with larger/smaller values is valid.
+    pub fn set_back(&mut self, left: f32, right: f32) {
+        self.raw[2] = left;
+        self.raw[3] = right;
     }
 
-    /// Returns a mutable reference to the "front" volume mix (left and right channel) for the specified auxiliary output device.
-    pub fn aux_front_mut(&mut self, id: usize) -> &mut [f32] {
+    /// Sets the values for the "front" volume mix (left and right channel) for the specified auxiliary output device (either 0 or 1).
+    ///
+    /// # Notes
+    ///
+    /// [Channel] will normalize the mix values to be within 0 and 1.
+    /// However, an [AudioMix] instance with larger/smaller values is valid.
+    pub fn set_aux_front(&mut self, left: f32, right: f32, id: usize) {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
 
         let index = 4 + id * 4;
 
-        &mut self.raw[index..index + 2]
+        self.raw[index] = left;
+        self.raw[index + 1] = right;
     }
 
-    /// Returns a mutable reference to the "back" volume mix (left and right channel) for the specified auxiliary output device.
-    pub fn aux_back_mut(&mut self, id: usize) -> &mut [f32] {
+    /// Sets the values for the "back" volume mix (left and right channel) for the specified auxiliary output device (either 0 or 1).
+    ///
+    /// # Notes
+    ///
+    /// [Channel] will normalize the mix values to be within 0 and 1.
+    /// However, an [AudioMix] instance with larger/smaller values is valid.
+    pub fn set_aux_back(&mut self, left: f32, right: f32, id: usize) {
         if id > 1 {
             panic!("invalid auxiliary output device index")
         }
 
         let index = 6 + id * 4;
 
-        &mut self.raw[index..index + 2]
+        self.raw[index] = left;
+        self.raw[index + 1] = right;
     }
 }
 
@@ -398,7 +422,7 @@ impl AudioMix {
 impl Default for AudioMix {
     fn default() -> Self {
         let mut mix = AudioMix::zeroed();
-        mix.front_mut().fill(1.);
+        mix.set_front(1.0, 1.0);
 
         mix
     }

--- a/ctru-rs/src/services/ndsp/wave.rs
+++ b/ctru-rs/src/services/ndsp/wave.rs
@@ -1,8 +1,8 @@
 use super::{AudioFormat, NdspError};
 use crate::linear::LinearAllocator;
 
-/// Informational struct holding the raw audio data and playback info. This corresponds to [ctru_sys::ndspWaveBuf]
-pub struct WaveInfo {
+/// Informational struct holding the raw audio data and playback info. This corresponds to [ctru_sys::ndspWaveBuf].
+pub struct Wave {
     /// Data block of the audio wave (and its format information).
     buffer: Box<[u8], LinearAllocator>,
     audio_format: AudioFormat,
@@ -13,7 +13,7 @@ pub struct WaveInfo {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
-/// Enum representing the playback status of a [WaveInfo].
+/// Enum representing the playback status of a [Wave].
 pub enum WaveStatus {
     Free = ctru_sys::NDSP_WBUF_FREE as u8,
     Queued = ctru_sys::NDSP_WBUF_QUEUED as u8,
@@ -21,14 +21,14 @@ pub enum WaveStatus {
     Done = ctru_sys::NDSP_WBUF_DONE as u8,
 }
 
-impl WaveInfo {
+impl Wave {
     /// Build a new playable wave object from a raw buffer on LINEAR memory and a some info.
     pub fn new(
         buffer: Box<[u8], LinearAllocator>,
         audio_format: AudioFormat,
         looping: bool,
     ) -> Self {
-        let sample_count: usize = buffer.len() / (audio_format.sample_size() as usize);
+        let sample_count = buffer.len() / audio_format.size();
 
         // Signal to the DSP processor the buffer's RAM sector.
         // This step may seem delicate, but testing reports failure most of the time, while still having no repercussions on the resulting audio.
@@ -69,10 +69,10 @@ impl WaveInfo {
     ///
     /// # Errors
     ///
-    /// This function will return an error if the [WaveInfo] is currently busy,
+    /// This function will return an error if the [Wave] is currently busy,
     /// with the id to the channel in which it's queued.
     pub fn get_buffer_mut(&mut self) -> Result<&mut [u8], NdspError> {
-        match self.get_status() {
+        match self.status() {
             WaveStatus::Playing | WaveStatus::Queued => {
                 Err(NdspError::WaveBusy(self.played_on_channel.unwrap()))
             }
@@ -81,7 +81,7 @@ impl WaveInfo {
     }
 
     /// Return this wave's playback status.
-    pub fn get_status(&self) -> WaveStatus {
+    pub fn status(&self) -> WaveStatus {
         self.raw_data.status.try_into().unwrap()
     }
 
@@ -90,12 +90,12 @@ impl WaveInfo {
     /// # Notes
     ///
     /// This value varies depending on [Self::set_sample_count].
-    pub fn get_sample_count(&self) -> u32 {
-        self.raw_data.nsamples
+    pub fn sample_count(&self) -> usize {
+        self.raw_data.nsamples as usize
     }
 
     /// Get the format of the audio data.
-    pub fn get_format(&self) -> AudioFormat {
+    pub fn format(&self) -> AudioFormat {
         self.audio_format
     }
 
@@ -117,25 +117,22 @@ impl WaveInfo {
     /// # Errors
     ///
     /// This function will return an error if the sample size exceeds the buffer's capacity
-    /// or if the WaveInfo is currently queued.
-    pub fn set_sample_count(&mut self, sample_count: u32) -> Result<(), NdspError> {
-        match self.get_status() {
+    /// or if the [Wave] is currently queued.
+    pub fn set_sample_count(&mut self, sample_count: usize) -> Result<(), NdspError> {
+        match self.status() {
             WaveStatus::Playing | WaveStatus::Queued => {
                 return Err(NdspError::WaveBusy(self.played_on_channel.unwrap()));
             }
             _ => (),
         }
 
-        let max_count: usize = self.buffer.len() / (self.audio_format.sample_size() as usize);
+        let max_count = self.buffer.len() / self.audio_format.size();
 
-        if sample_count > max_count as u32 {
-            return Err(NdspError::SampleCountOutOfBounds(
-                sample_count,
-                max_count as u32,
-            ));
+        if sample_count > max_count {
+            return Err(NdspError::SampleCountOutOfBounds(sample_count, max_count));
         }
 
-        self.raw_data.nsamples = sample_count;
+        self.raw_data.nsamples = sample_count as u32;
 
         Ok(())
     }
@@ -150,16 +147,16 @@ impl TryFrom<u8> for WaveStatus {
             1 => Ok(Self::Queued),
             2 => Ok(Self::Playing),
             3 => Ok(Self::Done),
-            _ => Err("Invalid WaveInfo Status code"),
+            _ => Err("Invalid Wave Status code"),
         }
     }
 }
 
-impl Drop for WaveInfo {
+impl Drop for Wave {
     fn drop(&mut self) {
-        // This was the only way I found I could check for improper drops of `WaveInfos`.
+        // This was the only way I found I could check for improper drops of `Wave`.
         // A panic was considered, but it would cause issues with drop order against `Ndsp`.
-        match self.get_status() {
+        match self.status() {
             WaveStatus::Free | WaveStatus::Done => (),
             // If the status flag is "unfinished"
             _ => {

--- a/ctru-rs/src/test_runner.rs
+++ b/ctru-rs/src/test_runner.rs
@@ -76,25 +76,3 @@ fn make_owned_test(test: &&TestDescAndFn) -> TestDescAndFn {
         _ => panic!("non-static tests passed to test::test_main_static"),
     }
 }
-
-/// The following functions are stubs needed to link the test library,
-/// but do nothing because we don't actually need them for the runner to work.
-mod link_fix {
-    #[no_mangle]
-    extern "C" fn execvp(
-        _argc: *const libc::c_char,
-        _argv: *mut *const libc::c_char,
-    ) -> libc::c_int {
-        -1
-    }
-
-    #[no_mangle]
-    extern "C" fn pipe(_fildes: *mut libc::c_int) -> libc::c_int {
-        -1
-    }
-
-    #[no_mangle]
-    extern "C" fn sigemptyset(_arg1: *mut libc::sigset_t) -> ::libc::c_int {
-        -1
-    }
-}


### PR DESCRIPTION
This PR comes as an after effect of my experience with #103 and needs for #102 and #97.

The focus points are: 
- `const fn` for `AudioFormat::size`
- creation of `AudioMix`
- rename of the methods (usually to avoid `get_` in getters)
- every "size" type changed into `usize` in the public interface, regardless of the underlying format.

The last two should be applied to all modules, but this PR only covers `Ndsp`.