### PR TITLE
Fix licensing and credits

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,0 @@
-# Authors
-
- * [Eidolon](https://github.com/HybridEidolon)
- * [FenrirWolf](https://github.com/FenrirWolf)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+As with the original ctrulib, this library is licensed under zlib. This
+applies to every file in the tree, unless otherwise noted.
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any
+    damages arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any
+    purpose, including commercial applications, and to alter it and
+    redistribute it freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you
+       must not claim that you wrote the original software. If you use
+       this software in a product, an acknowledgment in the product
+       documentation would be appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and
+       must not be misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source
+       distribution.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (C) Rust 3DS Project authors, 2015-2016
+
 As with the original ctrulib, this library is licensed under zlib. This
 applies to every file in the tree, unless otherwise noted.
 

--- a/README.md
+++ b/README.md
@@ -24,33 +24,10 @@ This repository is organized as follows:
   (displayed when built with `-vv`) will be issued if the build script detects
   a mismatch or is unable to check the installed `libctru` version.
 
-## License
+## Original version
 
-Copyright (C) Rust 3DS Project authors, 2015-2016
+This project is based on the efforts the original authors:
+ * [Eidolon](https://github.com/HybridEidolon)
+ * [FenrirWolf](https://github.com/FenrirWolf)
 
-See AUTHORS.md.
-
-As with the original ctrulib, this library is licensed under zlib. This
-applies to every file in the tree, unless otherwise noted.
-
-    This software is provided 'as-is', without any express or implied
-    warranty.  In no event will the authors be held liable for any
-    damages arising from the use of this software.
-
-    Permission is granted to anyone to use this software for any
-    purpose, including commercial applications, and to alter it and
-    redistribute it freely, subject to the following restrictions:
-
-    1. The origin of this software must not be misrepresented; you
-       must not claim that you wrote the original software. If you use
-       this software in a product, an acknowledgment in the product
-       documentation would be appreciated but is not required.
-    2. Altered source versions must be plainly marked as such, and
-       must not be misrepresented as being the original software.
-    3. This notice may not be removed or altered from any source
-       distribution.
-
-Rust is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0), with portions covered by various BSD-like licenses.
-
-See [LICENSE-APACHE](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE), [LICENSE-MIT](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT), and [COPYRIGHT](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) for details.
-
+The old version is archived [here](https://github.com/rust3ds/ctru-rs-old).

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Ronald Kinard <furyhunter600@gmail.com>"]
+authors = [ "Rust3DS Team", "Ronald Kinard <furyhunter600@gmail.com>" ]
 description = "A safe wrapper around smealum's ctrulib."
 license = "Zlib"
 name = "ctru-rs"

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = [ "Rust3DS Team", "Ronald Kinard <furyhunter600@gmail.com>" ]
+authors = [ "Rust3DS Org", "Ronald Kinard <furyhunter600@gmail.com>" ]
 description = "A safe wrapper around smealum's ctrulib."
 license = "Zlib"
 name = "ctru-rs"

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ctru-sys"
 version = "21.2.0+2.1.2-1"
-authors = ["Ronald Kinard <furyhunter600@gmail.com>"]
+authors = [ "Rust3DS Team", "Ronald Kinard <furyhunter600@gmail.com>" ]
 license = "Zlib"
 links = "ctru"
 edition = "2021"

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ctru-sys"
 version = "21.2.0+2.1.2-1"
-authors = [ "Rust3DS Team", "Ronald Kinard <furyhunter600@gmail.com>" ]
+authors = [ "Rust3DS Org", "Ronald Kinard <furyhunter600@gmail.com>" ]
 license = "Zlib"
 links = "ctru"
 edition = "2021"


### PR DESCRIPTION
With these changes the original authors are credited directly within the README and the license has been moved to a dedicated LICENSE file. Also, the Rust3DS Org is directly credited as author of the package, together with the original names.