### PR TITLE
Update for linker-fix-3ds rename

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -15,7 +15,7 @@ name = "ctru"
 cfg-if = "1.0"
 ctru-sys = { path = "../ctru-sys", version = "21.2" }
 const-zero = "0.1.0"
-linker-fix-3ds = { git = "https://github.com/rust3ds/rust-linker-fix-3ds.git" }
+shim-3ds = { git = "https://github.com/rust3ds/shim-3ds.git" }
 pthread-3ds = { git = "https://github.com/rust3ds/pthread-3ds.git" }
 libc = "0.2.121"
 bitflags = "1.0.0"

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -8,7 +8,7 @@
 #![test_runner(test_runner::run)]
 
 // Nothing is imported from these crates but their inclusion here assures correct linking of the missing implementations.
-extern crate linker_fix_3ds;
+extern crate shim_3ds;
 extern crate pthread_3ds;
 
 #[no_mangle]

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -8,8 +8,8 @@
 #![test_runner(test_runner::run)]
 
 // Nothing is imported from these crates but their inclusion here assures correct linking of the missing implementations.
-extern crate shim_3ds;
 extern crate pthread_3ds;
+extern crate shim_3ds;
 
 #[no_mangle]
 #[cfg(feature = "big-stack")]


### PR DESCRIPTION
Related to https://github.com/rust3ds/rust-linker-fix-3ds/issues/17

Must be pulled after https://github.com/rust3ds/rust-linker-fix-3ds/pull/21 and subsequent renaming of the repo.