### PR TITLE
Compilation error when romfs can't be found

### DIFF
--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -34,7 +34,7 @@ cfg_if::cfg_if! {
             //! [package.metadata.cargo-3ds]
             //! romfs_dir = "romfs"
             //! ```
-            
+
             compile_error!("romfs feature is enabled but no romfs found!");
         }
     }

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -34,6 +34,8 @@ cfg_if::cfg_if! {
             //! [package.metadata.cargo-3ds]
             //! romfs_dir = "romfs"
             //! ```
+            
+            compile_error!("romfs feature is enabled but no romfs found!");
         }
     }
 }

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -34,7 +34,7 @@ cfg_if::cfg_if! {
             //! [package.metadata.cargo-3ds]
             //! romfs_dir = "romfs"
             //! ```
-            
+
             // If the feature is set, but no "romfs" directory was found: send an error during compilation.
             #[cfg(feature = "romfs")]
             compile_error!("romfs feature is enabled but no romfs found!");

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -34,7 +34,9 @@ cfg_if::cfg_if! {
             //! [package.metadata.cargo-3ds]
             //! romfs_dir = "romfs"
             //! ```
-
+            
+            // If the feature is set, but no "romfs" directory was found: send an error during compilation.
+            #[cfg(feature = "romfs")]
             compile_error!("romfs feature is enabled but no romfs found!");
         }
     }


### PR DESCRIPTION
Closes #108 

This simply adds a compilation error if the feature is enabled, but the dir isn't properly set. Technically the end user would see compilation issues regardless (no `Romfs` struct found), but this way it's a bit more clear.