### PR TITLE
Handle empty Mii selector return

### DIFF
--- a/ctru-rs/examples/mii-selector.rs
+++ b/ctru-rs/examples/mii-selector.rs
@@ -1,4 +1,4 @@
-use ctru::applets::mii_selector::{LaunchError, MiiSelector};
+use ctru::applets::mii_selector::{LaunchError, MiiSelector, Options};
 use ctru::prelude::*;
 
 fn main() {

--- a/ctru-rs/examples/mii-selector.rs
+++ b/ctru-rs/examples/mii-selector.rs
@@ -10,13 +10,13 @@ fn main() {
     let _console = Console::new(gfx.top_screen.borrow_mut());
 
     let mut mii_selector = MiiSelector::new();
+    mii_selector.set_options(Options::MII_SELECTOR_CANCEL);
     mii_selector.set_initial_index(3);
     mii_selector.blacklist_user_mii(0.into());
     mii_selector.set_title("Great Mii Selector!");
 
     match mii_selector.launch() {
         Ok(result) => {
-            println!("Is Mii selected?: {:?}", result.is_mii_selected);
             println!("Mii type: {:?}", result.mii_type);
             println!("Name: {:?}", result.mii_data.name);
             println!("Author: {:?}", result.mii_data.author_name);

--- a/ctru-rs/examples/mii-selector.rs
+++ b/ctru-rs/examples/mii-selector.rs
@@ -1,4 +1,4 @@
-use ctru::applets::mii_selector::MiiSelector;
+use ctru::applets::mii_selector::{LaunchError, MiiSelector};
 use ctru::prelude::*;
 
 fn main() {
@@ -14,16 +14,20 @@ fn main() {
     mii_selector.blacklist_user_mii(0.into());
     mii_selector.set_title("Great Mii Selector!");
 
-    let result = mii_selector.launch().unwrap();
-
-    println!("Is Mii selected?: {:?}", result.is_mii_selected);
-    println!("Mii type: {:?}", result.mii_type);
-    println!("Name: {:?}", result.mii_data.name);
-    println!("Author: {:?}", result.mii_data.author_name);
-    println!(
-        "Does the Mii have moles?: {:?}",
-        result.mii_data.mole_details.is_enabled
-    );
+    match mii_selector.launch() {
+        Ok(result) => {
+            println!("Is Mii selected?: {:?}", result.is_mii_selected);
+            println!("Mii type: {:?}", result.mii_type);
+            println!("Name: {:?}", result.mii_data.name);
+            println!("Author: {:?}", result.mii_data.author_name);
+            println!(
+                "Does the Mii have moles?: {:?}",
+                result.mii_data.mole_details.is_enabled
+            );
+        }
+        Err(LaunchError::InvalidChecksum) => println!("Corrupt Mii selected"),
+        Err(LaunchError::NoMiiSelected) => println!("No Mii selected"),
+    }
 
     // Main loop
     while apt.main_loop() {

--- a/ctru-rs/src/applets/mii_selector.rs
+++ b/ctru-rs/src/applets/mii_selector.rs
@@ -65,7 +65,10 @@ pub struct SelectionResult {
 /// Error type for the Mii selector
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum LaunchError {
+    /// The selected Mii's data is corrupt in some way
     InvalidChecksum,
+
+    /// Either the user cancelled the selection (see [Options::MII_SELECTOR_CANCEL]), or no valid Miis were available to select
     NoMiiSelected,
 }
 

--- a/ctru-rs/src/applets/mii_selector.rs
+++ b/ctru-rs/src/applets/mii_selector.rs
@@ -56,9 +56,6 @@ pub struct MiiSelector {
 #[derive(Clone, Debug)]
 pub struct SelectionResult {
     pub mii_data: MiiData,
-
-    #[deprecated]
-    pub is_mii_selected: bool,
     pub mii_type: MiiType,
 }
 
@@ -67,7 +64,6 @@ pub struct SelectionResult {
 pub enum LaunchError {
     /// The selected Mii's data is corrupt in some way
     InvalidChecksum,
-
     /// Either the user cancelled the selection (see [Options::MII_SELECTOR_CANCEL]), or no valid Miis were available to select
     NoMiiSelected,
 }
@@ -178,7 +174,6 @@ impl From<ctru_sys::MiiSelectorReturn> for SelectionResult {
 
         SelectionResult {
             mii_data: raw_mii_data.into(),
-            is_mii_selected: ret.no_mii_selected == 0,
             mii_type: if ret.guest_mii_index != 0xFFFFFFFF {
                 MiiType::Guest {
                     index: ret.guest_mii_index,

--- a/ctru-rs/src/applets/mii_selector.rs
+++ b/ctru-rs/src/applets/mii_selector.rs
@@ -56,6 +56,8 @@ pub struct MiiSelector {
 #[derive(Clone, Debug)]
 pub struct SelectionResult {
     pub mii_data: MiiData,
+
+    #[deprecated]
     pub is_mii_selected: bool,
     pub mii_type: MiiType,
 }
@@ -64,6 +66,7 @@ pub struct SelectionResult {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum LaunchError {
     InvalidChecksum,
+    NoMiiSelected,
 }
 
 impl MiiSelector {
@@ -146,6 +149,10 @@ impl MiiSelector {
     pub fn launch(&mut self) -> Result<SelectionResult, LaunchError> {
         let mut return_val = Box::<ctru_sys::MiiSelectorReturn>::default();
         unsafe { ctru_sys::miiSelectorLaunch(self.config.as_mut(), return_val.as_mut()) }
+
+        if return_val.no_mii_selected != 0 {
+            return Err(LaunchError::NoMiiSelected);
+        }
 
         if unsafe { ctru_sys::miiSelectorChecksumIsValid(return_val.as_mut()) } {
             Ok((*return_val).into())


### PR DESCRIPTION
In some cases the Mii selector can fail even if `MII_SELECTOR_CANCEL` is not set. This PR accounts for this possibility and makes it so the user is never passed fake Mii data.

Closes #121 