### PR TITLE
Remove feature gate for stabilized feature (stabilized in 1.70.0)

### DIFF
--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(custom_test_frameworks)]
 #![feature(try_trait_v2)]
 #![feature(allocator_api)]
-#![feature(nonnull_slice_from_raw_parts)]
 #![test_runner(test_runner::run)]
 
 // Nothing is imported from these crates but their inclusion here assures correct linking of the missing implementations.


### PR DESCRIPTION
Remove feature gate for `nonnull_slice_from_raw_parts`

```rs
warning: the feature `nonnull_slice_from_raw_parts` has been stable since 1.70.0 and no longer requires an attribute to enable
 --> ctru-rs/src/lib.rs:7:12
  |
7 | #![feature(nonnull_slice_from_raw_parts)]
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(stable_features)]` on by default
```