### PR TITLE
add `set_initial_text` swkbd method

### DIFF
--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -7,7 +7,8 @@
 
 use bitflags::bitflags;
 use ctru_sys::{
-    self, swkbdInit, swkbdInputText, swkbdSetButton, swkbdSetFeatures, swkbdSetHintText, SwkbdState,
+    self, swkbdInit, swkbdInputText, swkbdSetButton, swkbdSetFeatures, swkbdSetHintText,
+    swkbdSetInitialText, SwkbdState,
 };
 use libc;
 use std::fmt::Display;
@@ -334,6 +335,30 @@ impl SoftwareKeyboard {
     /// # }
     pub fn set_max_digits(&mut self, digits: u16) {
         self.state.max_digits = digits;
+    }
+
+    /// Set the initial text for this software keyboard.
+    ///
+    /// The initial text is the text already written when you open the software keyboard.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # fn main() {
+    /// #
+    /// use ctru::applets::swkbd::SoftwareKeyboard;
+    /// let mut keyboard = SoftwareKeyboard::default();
+    ///
+    /// keyboard.set_initial_text("Write here what you like!");
+    /// #
+    /// # }
+    #[doc(alias = "swkbdSetInitialText")]
+    pub fn set_initial_text(&mut self, text: &str) {
+        unsafe {
+            let nul_terminated: String = text.chars().chain(once('\0')).collect();
+            swkbdSetInitialText(self.state.as_mut(), nul_terminated.as_ptr());
+        }
     }
 
     /// Set the hint text for this software keyboard.


### PR DESCRIPTION
Added the missing method for setting the initial text in the keyboard as documented [here](https://libctru.devkitpro.org/swkbd_8h.html#a3188c3c8f62da1f740e195976dcabf1f).

Some software keyboard methods are still missing, such as predictive input and custom dictionary words, but i didn't wanna implement them yet, as they require more data structures to wrap.