### PR TITLE
Implement `ac:u` and `ac:i` services (Wi-Fi info) + example

### DIFF
--- a/ctru-rs/examples/wifi-info.rs
+++ b/ctru-rs/examples/wifi-info.rs
@@ -1,0 +1,43 @@
+//! Wi-Fi info example
+//!
+//! This example prints out all the info about the console's network, like SSID, security, proxy info...
+
+use ctru::{prelude::*, services::ac::Ac};
+
+fn main() {
+    ctru::use_panic_handler();
+
+    let gfx = Gfx::new().expect("Couldn't obtain GFX controller");
+    let mut hid = Hid::new().expect("Couldn't obtain HID controller");
+    let apt = Apt::new().expect("Couldn't obtain APT controller");
+
+    let _console = Console::new(gfx.top_screen.borrow_mut());
+
+    let mut ac = Ac::new().expect("Couldn't get an AC handle");
+
+    print_network_info(&ac).expect("Error while gathering network info");
+    println!("Press START to exit.");
+
+    while apt.main_loop() {
+        hid.scan_input();
+
+        if hid.keys_down().contains(KeyPad::START) {
+            break;
+        }
+
+        gfx.wait_for_vblank();
+    }
+}
+
+fn print_network_info(ac: &Ac) -> ctru::Result<()> {
+    let connected = ac.get_wifi_status()?;
+    println!("Wi-Fi connected: {}", connected);
+
+    // Some methods error out if the console isn't connected
+    if connected {
+        println!("Wi-Fi SSID: {}", ac.get_wifi_ssid()?);
+        println!("Wi-Fi security: {:?}", ac.get_wifi_security()?);
+    }
+
+    Ok(())
+}

--- a/ctru-rs/examples/wifi-info.rs
+++ b/ctru-rs/examples/wifi-info.rs
@@ -29,7 +29,7 @@ fn main() {
 
 fn print_network_info(ac: &Ac) -> ctru::Result<()> {
     let connected = ac.get_wifi_status()?;
-    println!("Wi-Fi connected: {}", connected);
+    println!("Wi-Fi status: {:?}", connected);
 
     // Some methods error out if the console isn't connected
     if connected {

--- a/ctru-rs/examples/wifi-info.rs
+++ b/ctru-rs/examples/wifi-info.rs
@@ -37,6 +37,13 @@ fn print_network_info(ac: &Ac) -> ctru::Result<()> {
     if connected {
         println!("Wi-Fi SSID: {}", ac.get_wifi_ssid()?);
         println!("Wi-Fi security: {:?}", ac.get_wifi_security()?);
+        let proxied = ac.get_proxy_enabled()?;
+        println!("Proxy enabled: {}", proxied);
+        if proxied {
+            println!("Proxy port: {}", ac.get_proxy_port()?);
+            println!("Proxy username: {}", ac.get_proxy_username()?);
+            println!("Proxy password: {}", ac.get_proxy_password()?);
+        }
     }
 
     Ok(())

--- a/ctru-rs/examples/wifi-info.rs
+++ b/ctru-rs/examples/wifi-info.rs
@@ -5,8 +5,6 @@
 use ctru::{prelude::*, services::ac::Ac};
 
 fn main() {
-    ctru::use_panic_handler();
-
     let gfx = Gfx::new().expect("Couldn't obtain GFX controller");
     let mut hid = Hid::new().expect("Couldn't obtain HID controller");
     let apt = Apt::new().expect("Couldn't obtain APT controller");

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -96,8 +96,6 @@ pub enum Error {
     },
     /// An error that doesn't fit into the other categories.
     Other(String),
-    /// UTF-8 buffer to [String] conversion error
-    Utf8(std::string::FromUtf8Error),
 }
 
 impl Error {
@@ -139,12 +137,6 @@ impl From<ResultCode> for Error {
     }
 }
 
-impl From<std::string::FromUtf8Error> for Error {
-    fn from(err: std::string::FromUtf8Error) -> Self {
-        Error::Utf8(err)
-    }
-}
-
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -165,7 +157,6 @@ impl fmt::Debug for Error {
                 .field("wanted", wanted)
                 .finish(),
             Self::Other(err) => f.debug_tuple("Other").field(err).finish(),
-            Self::Utf8(e) => f.debug_tuple("Utf8").field(e).finish(),
         }
     }
 }
@@ -190,7 +181,6 @@ impl fmt::Display for Error {
             }
             Self::BufferTooShort{provided, wanted} => write!(f, "the provided buffer's length is too short (length = {provided}) to hold the wanted data (size = {wanted})"),
             Self::Other(err) => write!(f, "{err}"),
-            Self::Utf8(e) => write!(f, "UTF-8 conversion error: {e}")
         }
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -96,6 +96,8 @@ pub enum Error {
     },
     /// An error that doesn't fit into the other categories.
     Other(String),
+    /// UTF-8 buffer to [String] conversion error
+    Utf8(std::string::FromUtf8Error),
 }
 
 impl Error {
@@ -137,6 +139,12 @@ impl From<ResultCode> for Error {
     }
 }
 
+impl From<std::string::FromUtf8Error> for Error {
+    fn from(err: std::string::FromUtf8Error) -> Self {
+        Error::Utf8(err)
+    }
+}
+
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -157,6 +165,7 @@ impl fmt::Debug for Error {
                 .field("wanted", wanted)
                 .finish(),
             Self::Other(err) => f.debug_tuple("Other").field(err).finish(),
+            Self::Utf8(e) => f.debug_tuple("Utf8").field(e).finish(),
         }
     }
 }
@@ -181,6 +190,7 @@ impl fmt::Display for Error {
             }
             Self::BufferTooShort{provided, wanted} => write!(f, "the provided buffer's length is too short (length = {provided}) to hold the wanted data (size = {wanted})"),
             Self::Other(err) => write!(f, "{err}"),
+            Self::Utf8(e) => write!(f, "UTF-8 conversion error: {e}")
         }
     }
 }

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -271,34 +271,33 @@ impl Ac {
             Ok(String::from_utf8(vec)?)
         }
     }
-    /*
-        /// Load the selected network slot, if present.
-        ///
-        /// Note: this method requires `ac:i` access
-        /// # Example
-        ///
-        /// ```
-        /// # let _runner = test_runner::GdbRunner::default();
-        /// # use std::error::Error;
-        /// # fn main() -> Result<(), Box<dyn Error>> {
-        /// #
-        /// use ctru::services::ac::Ac;
-        ///
-        /// let ac = Ac::new()?;
-        ///
-        /// ac.load_network_slot(NetworkSlot::Second)?;
-        /// #
-        /// # Ok(())
-        /// # }
-        /// ```
-        #[doc(alias = "ACI_LoadNetworkSetting")]
-        pub fn load_network_slot(&self, slot: NetworkSlot) -> crate::Result<()> {
-            unsafe {
-                ResultCode(ctru_sys::ACI_LoadNetworkSetting(slot as u32))?;
-                Ok(())
-            }
+
+    /// Load the selected network slot, if present.
+    ///
+    /// Note: this method requires `ac:i` access
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    ///
+    /// ac.load_network_slot(NetworkSlot::Second)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACI_LoadNetworkSetting")]
+    pub fn load_network_slot(&self, slot: NetworkSlot) -> crate::Result<()> {
+        unsafe {
+            ResultCode(ctru_sys::ACI_LoadNetworkSetting(slot as u32))?;
+            Ok(())
         }
-    */
+    }
 }
 
 impl Drop for Ac {
@@ -331,7 +330,7 @@ pub enum SecurityMode {
     /// WPA2-AES authentication
     WPA2_AES = ctru_sys::AC_WPA2_AES,
 }
-/*
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum NetworkSlot {
@@ -339,6 +338,5 @@ pub enum NetworkSlot {
     Second = 1,
     Third = 2,
 }
-*/
 
 from_impl!(SecurityMode, ctru_sys::acSecurityMode);

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -74,32 +74,30 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// println!("Wi-Fi status: {:?}", ac.get_wifi_status()?);
+    /// println!("Wi-Fi status: {:?}", ac.wifi_status()?);
     /// #
     /// # Ok(())
     /// # }
     /// ```
     #[doc(alias = "ACU_GetWifiStatus")]
-    pub fn get_wifi_status(&self) -> crate::Result<NetworkStatus> {
+    pub fn wifi_status(&self) -> crate::Result<NetworkStatus> {
         unsafe {
             let mut ret = 0u32;
             ResultCode(ctru_sys::ACU_GetStatus(&mut ret))?;
 
-            Ok(
-                match ret {
-                    0 => NetworkStatus::None,
-                    1 => NetworkStatus::Idle,
-                    2 => NetworkStatus::LANConnected,
-                    3 => NetworkStatus::WANConnected,
-                    _ => Err(crate::Error::Other(format!("Unknown value {}", ret)))
-                }
-            )
+            Ok(match ret {
+                0 => NetworkStatus::None,
+                1 => NetworkStatus::Idle,
+                2 => NetworkStatus::LANConnected,
+                3 => NetworkStatus::WANConnected,
+                _ => return Err(crate::Error::Other(format!("Unknown value {}", ret))),
+            })
         }
     }
 
     /// Returns the [`SecurityMode`] of the currently connected network, or error if the console isn't connected to any network.
     ///
-    /// You can check if the console is connected to a network using [`Ac::get_wifi_status()`].
+    /// You can check if the console is connected to a network using [`Ac::wifi_status()`].
     /// # Example
     ///
     /// ```
@@ -111,8 +109,8 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// if ac.get_wifi_status()? == NetworkStatus::WANConnected {
-    ///     println!("Network security: {:?}", ac.get_wifi_security()?);
+    /// if ac.wifi_status()? == NetworkStatus::WANConnected {
+    ///     println!("Network security: {:?}", ac.wifi_security()?);
     /// }
     ///
     /// #
@@ -120,7 +118,7 @@ impl Ac {
     /// # }
     /// ```
     #[doc(alias = "ACU_GetWifiSecurityMode")]
-    pub fn get_wifi_security(&self) -> crate::Result<SecurityMode> {
+    pub fn wifi_security(&self) -> crate::Result<SecurityMode> {
         unsafe {
             let mut ret = 0u32;
             ResultCode(ctru_sys::ACU_GetSecurityMode(&mut ret))?;
@@ -139,14 +137,14 @@ impl Ac {
                 6 => SecurityMode::WPA_AES,
                 7 => SecurityMode::WPA2_AES,
 
-                _ => Err(crate::Error::Other(format!("Unknown value {}", ret)))
+                _ => return Err(crate::Error::Other(format!("Unknown value {}", ret))),
             })
         }
     }
 
     /// Returns the SSID of the Wi-Fi network the console is connected to, or error if the console isn't connected to any network.
     ///
-    /// You can check if the console is connected to a network using [`Ac::get_wifi_status()`].
+    /// You can check if the console is connected to a network using [`Ac::wifi_status()`].
     ///
     /// # Example
     ///
@@ -159,13 +157,13 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// println!("The console is connected to the network \"{}\"", ac.get_wifi_ssid().unwrap());
+    /// println!("The console is connected to the network \"{}\"", ac.wifi_ssid().unwrap());
     /// #
     /// # Ok(())
     /// # }
     /// ```
     #[doc(alias = "ACU_GetSSID")]
-    pub fn get_wifi_ssid(&self) -> crate::Result<String> {
+    pub fn wifi_ssid(&self) -> crate::Result<String> {
         unsafe {
             let mut len = 0u32;
             ResultCode(ctru_sys::ACU_GetSSIDLength(&mut len))?;
@@ -189,14 +187,14 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// println!("Proxy enabled: {}", ac.get_proxy_enabled()?);
+    /// println!("Proxy enabled: {}", ac.proxy_enabled()?);
     ///
     /// #
     /// # Ok(())
     /// # }
     /// ```
     #[doc(alias = "ACU_GetProxyEnable")]
-    pub fn get_proxy_enabled(&self) -> crate::Result<bool> {
+    pub fn proxy_enabled(&self) -> crate::Result<bool> {
         unsafe {
             let mut ret = false;
             ResultCode(ctru_sys::ACU_GetProxyEnable(&mut ret))?;
@@ -207,7 +205,7 @@ impl Ac {
 
     /// Returns the connected network's proxy port, if present.
     ///
-    /// You can check if the console is using a proxy with [`Ac::get_proxy_enabled()`]
+    /// You can check if the console is using a proxy with [`Ac::proxy_enabled()`]
     ///
     /// # Example
     ///
@@ -220,13 +218,13 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// println!("Proxy port: {}", ac.get_proxy_port()?);
+    /// println!("Proxy port: {}", ac.proxy_port()?);
     /// #
     /// # Ok(())
     /// # }
     /// ```
     #[doc(alias = "ACU_GetProxyPort")]
-    pub fn get_proxy_port(&self) -> crate::Result<u32> {
+    pub fn proxy_port(&self) -> crate::Result<u32> {
         unsafe {
             let mut ret = 0u32;
             ResultCode(ctru_sys::ACU_GetProxyPort(&mut ret))?;
@@ -237,7 +235,7 @@ impl Ac {
 
     /// Returns the connected network's proxy username, if present.
     ///
-    /// You can check if the console is using a proxy with [`Ac::get_proxy_enabled()`]
+    /// You can check if the console is using a proxy with [`Ac::proxy_enabled()`]
     ///
     /// # Example
     ///
@@ -250,14 +248,14 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// println!("Proxy username: {}", ac.get_proxy_username()?);
+    /// println!("Proxy username: {}", ac.proxy_username()?);
     ///
     /// #
     /// # Ok(())
     /// # }
     /// ```
     #[doc(alias = "ACU_GetProxyUserName")]
-    pub fn get_proxy_username(&self) -> crate::Result<String> {
+    pub fn proxy_username(&self) -> crate::Result<String> {
         unsafe {
             let mut vec = vec![0u8; 0x20];
             ResultCode(ctru_sys::ACU_GetProxyUserName(vec.as_mut_ptr()))?;
@@ -268,7 +266,7 @@ impl Ac {
 
     /// Returns the connected network's proxy password, if present.
     ///
-    /// You can check if the console is using a proxy with [`Ac::get_proxy_enabled()`]
+    /// You can check if the console is using a proxy with [`Ac::proxy_enabled()`]
     ///
     /// # Example
     ///
@@ -281,18 +279,18 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// println!("Proxy password: {}", ac.get_proxy_password()?);
+    /// println!("Proxy password: {}", ac.proxy_password()?);
     /// #
     /// # Ok(())
     /// # }
     /// ```
     #[doc(alias = "ACU_GetProxyPassword")]
-    pub fn get_proxy_password(&self) -> crate::Result<String> {
+    pub fn proxy_password(&self) -> crate::Result<String> {
         unsafe {
             let mut vec = vec![0u8; 0x20];
             ResultCode(ctru_sys::ACU_GetProxyPassword(vec.as_mut_ptr()))?;
 
-            Ok(String::from_utf8(vec)?)
+            Ok(String::from_utf8(vec))
         }
     }
 
@@ -316,7 +314,7 @@ impl Ac {
     /// # }
     /// ```
     #[doc(alias = "ACI_LoadNetworkSetting")]
-    pub fn load_network_slot(&self, slot: NetworkSlot) -> crate::Result<()> {
+    pub fn load_network_slot(&mut self, slot: NetworkSlot) -> crate::Result<()> {
         unsafe {
             ResultCode(ctru_sys::ACI_LoadNetworkSetting(slot as u32))?;
             Ok(())
@@ -380,7 +378,7 @@ pub enum NetworkStatus {
     /// Connected, only LAN.
     LANConnected = 2,
     /// Connected to the Internet.
-    WANConnected = 3
+    WANConnected = 3,
 }
 
 from_impl!(SecurityMode, ctru_sys::acSecurityMode);

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -1,6 +1,10 @@
+//! The Automatic Connection (AC) service handles Wi-Fi and network settings.
+//! It can:
+//! - Connect to a network or slot
+//! - Get information about a network, such as its SSID or security settings
 use crate::error::ResultCode;
 
-/// Handle to the AC service, that handles Wi-Fi and network settings.
+/// Handle to the Automatic Connection (AC) service, that handles Wi-Fi and network settings.
 pub struct Ac(());
 
 impl Ac {
@@ -128,7 +132,7 @@ impl Ac {
     ///
     /// let ac = Ac::new()?;
     ///
-    /// println!("The console is connected to the network \"{}\"", ac.get_wifi_ssid().unwrap())
+    /// println!("The console is connected to the network \"{}\"", ac.get_wifi_ssid().unwrap());
     /// #
     /// # Ok(())
     /// # }
@@ -267,34 +271,34 @@ impl Ac {
             Ok(String::from_utf8(vec)?)
         }
     }
-
     /*
-    /// Load the selected network slot, if present.
-    ///
-    /// Note: this method requires `ac:i` access
-    /// # Example
-    ///
-    /// ```
-    /// # let _runner = test_runner::GdbRunner::default();
-    /// # use std::error::Error;
-    /// # fn main() -> Result<(), Box<dyn Error>> {
-    /// #
-    /// use ctru::services::ac::Ac;
-    ///
-    /// let ac = Ac::new()?;
-    ///
-    /// ac.load_network_slot(NetworkSlot::Second)?;
-    /// #
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[doc(alias = "ACI_LoadNetworkSetting")]
-    pub fn load_network_slot(&self, slot: NetworkSlot) -> crate::Result<()> {
-        unsafe {
-            ResultCode(ctru_sys::ACI_LoadNetworkSetting(slot as u32))?;
-            Ok(())
+        /// Load the selected network slot, if present.
+        ///
+        /// Note: this method requires `ac:i` access
+        /// # Example
+        ///
+        /// ```
+        /// # let _runner = test_runner::GdbRunner::default();
+        /// # use std::error::Error;
+        /// # fn main() -> Result<(), Box<dyn Error>> {
+        /// #
+        /// use ctru::services::ac::Ac;
+        ///
+        /// let ac = Ac::new()?;
+        ///
+        /// ac.load_network_slot(NetworkSlot::Second)?;
+        /// #
+        /// # Ok(())
+        /// # }
+        /// ```
+        #[doc(alias = "ACI_LoadNetworkSetting")]
+        pub fn load_network_slot(&self, slot: NetworkSlot) -> crate::Result<()> {
+            unsafe {
+                ResultCode(ctru_sys::ACI_LoadNetworkSetting(slot as u32))?;
+                Ok(())
+            }
         }
-    }*/
+    */
 }
 
 impl Drop for Ac {
@@ -327,13 +331,14 @@ pub enum SecurityMode {
     /// WPA2-AES authentication
     WPA2_AES = ctru_sys::AC_WPA2_AES,
 }
-
 /*
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum NetworkSlot {
     First = 0,
     Second = 1,
-    Third = 2
+    Third = 2,
 }
 */
+
+from_impl!(SecurityMode, ctru_sys::acSecurityMode);

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -1,0 +1,170 @@
+use crate::error::ResultCode;
+use std::ffi::CString;
+use std::io::Write;
+use std::marker::PhantomData;
+pub struct Ac(());
+
+impl Ac {
+    /// Initialize a new service handle.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "acInit")]
+    pub fn new() -> crate::Result<Ac> {
+        unsafe {
+            ResultCode(ctru_sys::acInit())?;
+            Ok(Ac(()))
+        }
+    }
+
+    /// Waits for an internet connection
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// println!("Waiting for an internet connection...");
+    /// ac.wait_for_internet_connection()?;
+    /// println!("Connected.");
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "acWaitInternetConnection")]
+    pub fn wait_internet_connection(&self) -> crate::Result<()> {
+        unsafe {
+            ResultCode(ctru_sys::acWaitInternetConnection())?;
+
+            Ok(())
+        }
+    }
+
+    /// Returns whether the console is connected to Wi-Fi
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// println!("Wi-Fi connected: {}", ac.get_wifi_status()?);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACU_GetWifiStatus")]
+    pub fn get_wifi_status(&self) -> crate::Result<bool> {
+        unsafe {
+            let mut ret = 0u32;
+            ResultCode(ctru_sys::ACU_GetStatus(&mut ret))?;
+
+            Ok(ret == 3)
+        }
+    }
+
+    /// Returns whether the console is connected to Wi-Fi
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACU_GetWifiSecurityMode")]
+    pub fn get_wifi_security(&self) -> crate::Result<SecurityMode> {
+        unsafe {
+            let mut ret = 0u32;
+            ResultCode(ctru_sys::ACU_GetSecurityMode(&mut ret))?;
+            // fix this, for some reason the bindings have the type as a struct and not enum
+            // and so i can't impl TryFrom automatically
+            Ok(std::mem::transmute(ret))
+        }
+    }
+
+    /// Returns the SSID of the Wi-Fi network the console is connected to, or error if the console isn't connected to any network.
+    /// 
+    /// You can check if the console is connected to a network using [`Self::get_wifi_status()`]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// println!("The console is connected to the network \"{}\"", ac.get_wifi_ssid().unwrap())
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACU_GetSSID")]
+    pub fn get_wifi_ssid(&self) -> crate::Result<String> {
+        unsafe {
+            let mut len = 0u32;
+            ResultCode(ctru_sys::ACU_GetSSIDLength(&mut len))?;
+            // we don't really need space for the terminator
+            let mut vec: Vec<u8> = vec![0u8; len as usize];
+            ResultCode(ctru_sys::ACU_GetSSID(vec.as_mut_ptr()))?;
+            // how do i handle this error?
+            Ok(String::from_utf8(vec).unwrap())
+        }
+    }
+}
+
+impl Drop for Ac {
+    #[doc(alias = "acExit")]
+    fn drop(&mut self) {
+        unsafe { ctru_sys::acExit() };
+    }
+}
+
+#[doc(alias = "acSecurityMode")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum SecurityMode {
+    Open = 0,
+    WEP40Bit = 1,
+    WEP104Bit = 2,
+    WEP128Bit = 3,
+    WPA_TKIP = 4,
+    WPA2_TKIP = 5,
+    WPA_AES = 6,
+    WPA2_AES = 7
+}

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -336,13 +336,6 @@ impl Ac {
     }
 }
 
-impl Drop for Ac {
-    #[doc(alias = "acExit")]
-    fn drop(&mut self) {
-        unsafe { ctru_sys::acExit() };
-    }
-}
-
 #[doc(alias = "acSecurityMode")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -1,4 +1,6 @@
 use crate::error::ResultCode;
+
+/// Handle to the AC service, that handles Wi-Fi and network settings.
 pub struct Ac(());
 
 impl Ac {
@@ -306,15 +308,24 @@ impl Drop for Ac {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 #[non_exhaustive]
+/// Represents all the supported Wi-Fi security modes.
 pub enum SecurityMode {
-    Open = 0,
-    WEP40Bit = 1,
-    WEP104Bit = 2,
-    WEP128Bit = 3,
-    WPA_TKIP = 4,
-    WPA2_TKIP = 5,
-    WPA_AES = 6,
-    WPA2_AES = 7,
+    /// No authentication
+    Open = ctru_sys::AC_OPEN,
+    /// WEP 40bit authentication
+    WEP40Bit = ctru_sys::AC_WEP_40BIT,
+    /// WEP 104bit authentication
+    WEP104Bit = ctru_sys::AC_WEP_104BIT,
+    /// WEP 128bit authentication
+    WEP128Bit = ctru_sys::AC_WEP_128BIT,
+    /// WPA-TKIP authentication
+    WPA_TKIP = ctru_sys::AC_WPA_TKIP,
+    /// WPA2-TKIP authentication
+    WPA2_TKIP = ctru_sys::AC_WPA2_TKIP,
+    /// WPA-AES authentication
+    WPA_AES = ctru_sys::AC_WPA_AES,
+    /// WPA2-AES authentication
+    WPA2_AES = ctru_sys::AC_WPA2_AES,
 }
 
 /*

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -140,8 +140,130 @@ impl Ac {
             let mut len = 0u32;
             ResultCode(ctru_sys::ACU_GetSSIDLength(&mut len))?;
             // we don't really need space for the terminator
-            let mut vec: Vec<u8> = vec![0u8; len as usize];
+            let mut vec = vec![0u8; len as usize];
             ResultCode(ctru_sys::ACU_GetSSID(vec.as_mut_ptr()))?;
+            // how do i handle this error?
+            Ok(String::from_utf8(vec).unwrap())
+        }
+    }
+
+    /// Returns whether the console is connected to a proxy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// println!("Proxy enabled: {}", ac.get_proxy_enabled()?);
+    /// 
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACU_GetProxyEnable")]
+    pub fn get_proxy_enabled(&self) -> crate::Result<bool> {
+        unsafe {
+            let mut ret = false;
+            ResultCode(ctru_sys::ACU_GetProxyEnable(&mut ret))?;
+
+            Ok(ret)
+        }
+    }
+
+    /// Returns the connected network's proxy port, if present.
+    ///
+    /// You can check if the console is using a proxy with [`Self::get_proxy_enabled()`]
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// println!("Proxy port: {}", ac.get_proxy_port()?);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACU_GetProxyPort")]
+    pub fn get_proxy_port(&self) -> crate::Result<u32> {
+        unsafe {
+            let mut ret = 0u32;
+            ResultCode(ctru_sys::ACU_GetProxyPort(&mut ret))?;
+
+            Ok(ret)
+        }
+    }
+
+    /// Returns the connected network's proxy username, if present.
+    ///
+    /// You can check if the console is using a proxy with [`Self::get_proxy_enabled()`]
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// println!("Proxy username: {}", ac.get_proxy_username()?);
+    /// 
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACU_GetProxyUserName")]
+    pub fn get_proxy_username(&self) -> crate::Result<String> {
+        unsafe {
+            let mut vec = vec![0u8; 0x20];
+            ResultCode(ctru_sys::ACU_GetProxyUserName(vec.as_mut_ptr()))?;
+
+            // how do i handle this error?
+            Ok(String::from_utf8(vec).unwrap())
+        }
+    }
+
+    /// Returns the connected network's proxy password, if present.
+    ///
+    /// You can check if the console is using a proxy with [`Self::get_proxy_enabled()`]
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    /// 
+    /// println!("Proxy password: {}", ac.get_proxy_password()?);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACU_GetProxyPassword")]
+    pub fn get_proxy_password(&self) -> crate::Result<String> {
+        unsafe {
+            let mut vec = vec![0u8; 0x20];
+            ResultCode(ctru_sys::ACU_GetProxyPassword(vec.as_mut_ptr()))?;
+
             // how do i handle this error?
             Ok(String::from_utf8(vec).unwrap())
         }

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -32,15 +32,17 @@ impl Ac {
     #[doc(alias = "acInit")]
     pub fn new() -> crate::Result<Ac> {
         Ok(Ac {
-            _service_handler: ServiceReference::new(&AC_ACTIVE, 
+            _service_handler: ServiceReference::new(
+                &AC_ACTIVE,
                 || {
                     ResultCode(unsafe { ctru_sys::acInit() })?;
-    
+
                     Ok(())
                 },
                 || unsafe {
                     ctru_sys::acExit();
-                },)?
+                },
+            )?,
         })
     }
 

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -1,7 +1,4 @@
 use crate::error::ResultCode;
-use std::ffi::CString;
-use std::io::Write;
-use std::marker::PhantomData;
 pub struct Ac(());
 
 impl Ac {
@@ -43,7 +40,7 @@ impl Ac {
     /// let ac = Ac::new()?;
     ///
     /// println!("Waiting for an internet connection...");
-    /// ac.wait_for_internet_connection()?;
+    /// ac.wait_internet_connection()?;
     /// println!("Connected.");
     /// #
     /// # Ok(())
@@ -143,7 +140,7 @@ impl Ac {
             let mut vec = vec![0u8; len as usize];
             ResultCode(ctru_sys::ACU_GetSSID(vec.as_mut_ptr()))?;
             // how do i handle this error?
-            Ok(String::from_utf8(vec).unwrap())
+            Ok(String::from_utf8(vec)?)
         }
     }
 
@@ -234,7 +231,7 @@ impl Ac {
             ResultCode(ctru_sys::ACU_GetProxyUserName(vec.as_mut_ptr()))?;
 
             // how do i handle this error?
-            Ok(String::from_utf8(vec).unwrap())
+            Ok(String::from_utf8(vec)?)
         }
     }
 
@@ -265,7 +262,7 @@ impl Ac {
             ResultCode(ctru_sys::ACU_GetProxyPassword(vec.as_mut_ptr()))?;
 
             // how do i handle this error?
-            Ok(String::from_utf8(vec).unwrap())
+            Ok(String::from_utf8(vec)?)
         }
     }
 
@@ -308,6 +305,7 @@ impl Drop for Ac {
 #[doc(alias = "acSecurityMode")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum SecurityMode {
     Open = 0,
     WEP40Bit = 1,

--- a/ctru-rs/src/services/ac.rs
+++ b/ctru-rs/src/services/ac.rs
@@ -41,7 +41,7 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// println!("Waiting for an internet connection...");
     /// ac.wait_for_internet_connection()?;
     /// println!("Connected.");
@@ -70,7 +70,7 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// println!("Wi-Fi connected: {}", ac.get_wifi_status()?);
     /// #
     /// # Ok(())
@@ -98,7 +98,7 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// #
     /// # Ok(())
     /// # }
@@ -115,7 +115,7 @@ impl Ac {
     }
 
     /// Returns the SSID of the Wi-Fi network the console is connected to, or error if the console isn't connected to any network.
-    /// 
+    ///
     /// You can check if the console is connected to a network using [`Self::get_wifi_status()`]
     ///
     /// # Example
@@ -128,7 +128,7 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// println!("The console is connected to the network \"{}\"", ac.get_wifi_ssid().unwrap())
     /// #
     /// # Ok(())
@@ -159,9 +159,9 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// println!("Proxy enabled: {}", ac.get_proxy_enabled()?);
-    /// 
+    ///
     /// #
     /// # Ok(())
     /// # }
@@ -179,7 +179,7 @@ impl Ac {
     /// Returns the connected network's proxy port, if present.
     ///
     /// You can check if the console is using a proxy with [`Self::get_proxy_enabled()`]
-    /// 
+    ///
     /// # Example
     ///
     /// ```
@@ -190,7 +190,7 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// println!("Proxy port: {}", ac.get_proxy_port()?);
     /// #
     /// # Ok(())
@@ -209,7 +209,7 @@ impl Ac {
     /// Returns the connected network's proxy username, if present.
     ///
     /// You can check if the console is using a proxy with [`Self::get_proxy_enabled()`]
-    /// 
+    ///
     /// # Example
     ///
     /// ```
@@ -220,9 +220,9 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// println!("Proxy username: {}", ac.get_proxy_username()?);
-    /// 
+    ///
     /// #
     /// # Ok(())
     /// # }
@@ -241,7 +241,7 @@ impl Ac {
     /// Returns the connected network's proxy password, if present.
     ///
     /// You can check if the console is using a proxy with [`Self::get_proxy_enabled()`]
-    /// 
+    ///
     /// # Example
     ///
     /// ```
@@ -252,7 +252,7 @@ impl Ac {
     /// use ctru::services::ac::Ac;
     ///
     /// let ac = Ac::new()?;
-    /// 
+    ///
     /// println!("Proxy password: {}", ac.get_proxy_password()?);
     /// #
     /// # Ok(())
@@ -268,6 +268,34 @@ impl Ac {
             Ok(String::from_utf8(vec).unwrap())
         }
     }
+
+    /*
+    /// Load the selected network slot, if present.
+    ///
+    /// Note: this method requires `ac:i` access
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// #
+    /// use ctru::services::ac::Ac;
+    ///
+    /// let ac = Ac::new()?;
+    ///
+    /// ac.load_network_slot(NetworkSlot::Second)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "ACI_LoadNetworkSetting")]
+    pub fn load_network_slot(&self, slot: NetworkSlot) -> crate::Result<()> {
+        unsafe {
+            ResultCode(ctru_sys::ACI_LoadNetworkSetting(slot as u32))?;
+            Ok(())
+        }
+    }*/
 }
 
 impl Drop for Ac {
@@ -288,5 +316,15 @@ pub enum SecurityMode {
     WPA_TKIP = 4,
     WPA2_TKIP = 5,
     WPA_AES = 6,
-    WPA2_AES = 7
+    WPA2_AES = 7,
 }
+
+/*
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum NetworkSlot {
+    First = 0,
+    Second = 1,
+    Third = 2
+}
+*/

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -26,6 +26,7 @@ mod reference;
 pub mod soc;
 pub mod sslc;
 pub mod svc;
+pub mod ac;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "romfs", romfs_exists))] {

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -11,6 +11,7 @@
 //!
 //! In [`ctru-rs`](crate) some services only allow a single handle to be created at a time, to ensure a safe and controlled environment.
 
+pub mod ac;
 pub mod am;
 pub mod apt;
 pub mod cam;
@@ -26,7 +27,6 @@ mod reference;
 pub mod soc;
 pub mod sslc;
 pub mod svc;
-pub mod ac;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "romfs", romfs_exists))] {


### PR DESCRIPTION
Implements the `ac` service, both `ac:u` (user) and `ac:i` methods (intended for mset).

Did this because i needed some of these methods for an app

Methods implemented:
- [x] `wait_internet_connection` (returns immediately for some reason independently of network connection, have to investigate)
- [x] `get_wifi_status`
- [x] `get_wifi_security`
- [x] `get_wifi_ssid`
- [x] `get_proxy_enabled`
- [x] `get_proxy_port`
- [x] `get_proxy_username`
- [x] `get_proxy_password`
- [x] `load_network_slot` (`ac:i`)
- [ ] `ACU_SetAllowApType`
- [ ] `ACU_SetNetworkArea`
- [ ] `ACU_SetRequestEulaVersion`
- [ ] `ACU_CreateDefaultConfig`
- [ ] `ACU_ConnectAsync`, `ACU_GetLastErrorCode` and `ACU_GetLastDetailErrorCode` (all at once)
- [ ] `ACI_GetNetworkWirelessEssidSecurity`

(screenshot didnt work)
![PXL_20231028_105524873](https://github.com/rust3ds/ctru-rs/assets/46694241/b5d33777-9820-476e-8dbc-aa0927c204e2)
