### PR TITLE
Initial docs workflow for Github Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+
+      - uses: rust3ds/test-runner/setup@v1
+        with:
+          toolchain: nightly
+
+      - name: Build workspace docs
+        run: cargo 3ds --verbose doc --verbose --no-deps --workspace
+        env:
+          RUSTDOCFLAGS: --enable-index-page
+
+      # https://github.com/actions/upload-pages-artifact#file-permissions
+      - name: Fix file permissions
+        run: |
+          chmod -c -R +rX "target/armv6k-nintendo-3ds/doc" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
+      - name: Copy generated docs to _site
+        # Note: this won't include proc-macro crate, but macros are re-exported
+        # by the crate docs so there will still be some documentation.
+        run: cp -R ./target/armv6k-nintendo-3ds/doc ./_site/crates
+
+      - name: Upload docs
+        uses: actions/upload-pages-artifact@v2
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+

--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ This repository is home of the `ctru-rs` project, which aims to bring full contr
 
 This repository is organized as follows:
 
-  * [`ctru-rs`](./ctru-rs/) - Safe, idiomatic wrapper around [`ctru-sys`](./ctru-sys/).
-  * [`ctru-sys`](./ctru-sys/) - Low-level, unsafe bindings to [`libctru`](https://github.com/devkitPro/libctru).
+  * [`ctru-rs`](./ctru-rs) - Safe, idiomatic wrapper around [`ctru-sys`](./ctru-sys).
+  * [`ctru-sys`](./ctru-sys) - Low-level, unsafe bindings to [`libctru`](https://github.com/devkitPro/libctru).
 
 ## Getting Started
 
 Specific information about how to use the crates is present in the individual README for each package.
 Have a look at `ctru-rs`' [README.md](./ctru-rs/README.md) for a broad overview.
+
+## Documentation
+
+Cargo-generated [documentation](https://rust3ds.github.io/ctru-rs/crates) is available
+via GitHub Pages, because the <https://docs.rs> build environment does not have `libctru`
+installed.
 
 ## Original version
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+# Configuration for GitHub Pages (Jekyll)
+theme: jekyll-theme-midnight

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,15 @@
+---
+---
+
+// https://github.com/pages-themes/midnight#stylesheet
+@import "{{ site.theme }}";
+
+// Give code links a color that matches regular links
+a code {
+    color: inherit;
+}
+
+// Remove weird extra padding and spaces from inline code blocks
+code {
+    padding: 0;
+}

--- a/ctru-rs/README.md
+++ b/ctru-rs/README.md
@@ -2,6 +2,8 @@
 
 Safe and idiomatic Rust wrapper around [`libctru`](https://github.com/devkitPro/libctru).
 
+Documentation for the `master` branch can be found [here](https://rust3ds.github.io/ctru-rs/crates/ctru).
+
 ## Getting Started
 
 Thoroughly read the [`ctru-rs` wiki](https://github.com/rust3ds/ctru-rs/wiki/Getting-Started) to meet the requirements

--- a/ctru-sys/README.md
+++ b/ctru-sys/README.md
@@ -2,6 +2,9 @@
 
 Raw Rust bindings over the [`libctru`](https://github.com/devkitPro/libctru) C library.
 
+Documentation for the latest devkitPro release can be found
+[here](https://rust3ds.github.io/crates/ctru_sys).
+
 ## Requirements
 
 To use the bindings provided by this crate you will need to link against the [`libctru`](https://github.com/devkitPro/libctru) library.


### PR DESCRIPTION
Closes #144 

With this (and maybe some repo settings), generated docs should be available via GH Pages at https://rust3ds.github.io/ctru-rs !