### PR TITLE
Fix broken link and use proper branch name for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:

--- a/ctru-sys/README.md
+++ b/ctru-sys/README.md
@@ -2,8 +2,9 @@
 
 Raw Rust bindings over the [`libctru`](https://github.com/devkitPro/libctru) C library.
 
-Documentation for the latest devkitPro release can be found
-[here](https://rust3ds.github.io/crates/ctru_sys).
+Documentation for the latest devkitPro release
+[on Docker Hub](https://hub.docker.com/r/devkitpro/devkitarm/)
+can be found [here](https://rust3ds.github.io/ctru-rs/crates/ctru_sys).
 
 ## Requirements
 


### PR DESCRIPTION
Follow up to #145 to fix some small bugs. This should automatically deploy once merged.