### PR TITLE
Add docs page to packate manifest

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.7.1"
 authors = ["Rust3DS Org", "Ronald Kinard <furyhunter600@gmail.com>"]
 description = "A safe wrapper around libctru"
 repository = "https://github.com/rust3ds/ctru-rs"
+documentation = "https://rust3ds.github.io/ctru-rs/crates/ctru"
 keywords = ["3ds", "libctru"]
 categories = ["os", "api-bindings", "hardware-support"]
 exclude = ["examples"]

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.5.0"
 authors = ["Rust3DS Org", "Ronald Kinard <furyhunter600@gmail.com>"]
 description = "Raw bindings to libctru"
 repository = "https://github.com/rust3ds/ctru-rs"
+documentation = "https://rust3ds.github.io/ctru-rs/crates/ctru_sys"
 keywords = ["3ds", "libctru"]
 categories = ["os", "external-ffi-bindings", "no-std", "hardware-support"]
 exclude = ["src/.gitattributes"]


### PR DESCRIPTION
Simple change to show the correct docs page on [crates.io](https://crates.io).