### PR TITLE
Get software keyboard input without max byte size parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           # Run against a "known good" nightly. Rustc version is 1 day behind the toolchain date
-          - nightly-2023-06-01
+          - nightly-2024-02-18
           # Check for breakage on latest nightly
           - nightly
 
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - nightly-2023-06-01
+          - nightly-2024-02-18
           - nightly
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     runs-on: ubuntu-latest

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["os", "api-bindings", "hardware-support"]
 exclude = ["examples"]
 license = "Zlib"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.73"
 
 [lib]
 crate-type = ["rlib"]

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -24,6 +24,7 @@ shim-3ds = { git = "https://github.com/rust3ds/shim-3ds.git" }
 pthread-3ds = { git = "https://github.com/rust3ds/pthread-3ds.git" }
 libc = "0.2.121"
 bitflags = "2.3.3"
+widestring = "1.0.2"
 
 [build-dependencies]
 toml = "0.5"

--- a/ctru-rs/examples/file-explorer.rs
+++ b/ctru-rs/examples/file-explorer.rs
@@ -165,7 +165,7 @@ impl<'a> FileExplorer<'a> {
     fn get_input_and_run(&mut self, action: impl FnOnce(&mut Self, String)) {
         let mut keyboard = SoftwareKeyboard::default();
 
-        match keyboard.get_string(self.apt, self.gfx) {
+        match keyboard.launch(self.apt, self.gfx) {
             Ok((path, Button::Right)) => {
                 // Clicked "OK".
                 action(self, path);

--- a/ctru-rs/examples/file-explorer.rs
+++ b/ctru-rs/examples/file-explorer.rs
@@ -165,7 +165,7 @@ impl<'a> FileExplorer<'a> {
     fn get_input_and_run(&mut self, action: impl FnOnce(&mut Self, String)) {
         let mut keyboard = SoftwareKeyboard::default();
 
-        match keyboard.get_string(2048, self.apt, self.gfx) {
+        match keyboard.get_string(self.apt, self.gfx) {
             Ok((path, Button::Right)) => {
                 // Clicked "OK".
                 action(self, path);

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -44,9 +44,9 @@ fn main() {
 
         // Check if the user request to write some input.
         if hid.keys_down().contains(KeyPad::A) {
-            // Raise the software keyboard. You can perform different actions depending on which
+            // Launch the software keyboard. You can perform different actions depending on which
             // software button the user pressed.
-            match keyboard.get_string(&apt, &gfx) {
+            match keyboard.launch(&apt, &gfx) {
                 Ok((text, Button::Right)) => println!("You entered: {text}"),
                 Ok((_, Button::Left)) => println!("Cancelled"),
                 Ok((_, Button::Middle)) => println!("How did you even press this?"),

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -46,7 +46,7 @@ fn main() {
         if hid.keys_down().contains(KeyPad::A) {
             // Raise the software keyboard. You can perform different actions depending on which
             // software button the user pressed.
-            match keyboard.get_string(2048, &apt, &gfx) {
+            match keyboard.get_string(&apt, &gfx) {
                 Ok((text, Button::Right)) => println!("You entered: {text}"),
                 Ok((_, Button::Left)) => println!("Cancelled"),
                 Ok((_, Button::Middle)) => println!("How did you even press this?"),

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -5,10 +5,10 @@
 
 use crate::services::{apt::Apt, gfx::Gfx};
 use ctru_sys::{
-    self, aptLaunchLibraryApplet, aptSetMessageCallback, envGetAptAppId, svcBreak, svcCloseHandle,
+    self, aptLaunchLibraryApplet, aptSetMessageCallback, envGetAptAppId, svcCloseHandle,
     svcCreateMemoryBlock, APT_SendParameter, SwkbdButton, SwkbdDictWord, SwkbdExtra,
     SwkbdLearningData, SwkbdState, SwkbdStatusData, APPID_SOFTWARE_KEYBOARD, APTCMD_MESSAGE,
-    NS_APPID, SWKBD_CALLBACK_OK, USERBREAK_PANIC,
+    NS_APPID, SWKBD_CALLBACK_OK,
 };
 
 use bitflags::bitflags;
@@ -281,7 +281,7 @@ impl SoftwareKeyboard {
                 (self as *mut Self).cast(),
             );
 
-            match Self::swkbd_input_text(self.state.as_mut(), output.as_mut_vec()) {
+            match Self::swkbd_input_text(self.state.as_mut(), &mut output) {
                 ctru_sys::SWKBD_BUTTON_NONE => Err(self.state.result.into()),
                 ctru_sys::SWKBD_BUTTON_LEFT => Ok((output, Button::Left)),
                 ctru_sys::SWKBD_BUTTON_MIDDLE => Ok((output, Button::Middle)),
@@ -631,7 +631,7 @@ impl SoftwareKeyboard {
     // A reimplementation of `swkbdInputText` from `libctru/source/applets/swkbd.c`. Allows us to
     // get text from the software keyboard and put it directly into a `String` without requiring
     // an intermediate fixed-size buffer
-    fn swkbd_input_text(swkbd: &mut SwkbdState, buf: &mut Vec<u8>) -> SwkbdButton {
+    fn swkbd_input_text(swkbd: &mut SwkbdState, output: &mut String) -> SwkbdButton {
         use ctru_sys::{
             MEMPERM_READ, MEMPERM_WRITE, R_FAILED, SWKBD_BUTTON_LEFT, SWKBD_BUTTON_MIDDLE,
             SWKBD_BUTTON_NONE, SWKBD_BUTTON_RIGHT, SWKBD_D0_CLICK, SWKBD_D1_CLICK0,
@@ -715,11 +715,11 @@ impl SoftwareKeyboard {
             swkbd.initial_text_offset = 0;
 
             unsafe {
-                let utf16_iter = CStr::from_ptr(extra.initial_text)
-                    .to_str()
-                    .unwrap()
-                    .encode_utf16()
-                    .chain(once(0));
+                let utf16_iter =
+                    str::from_utf8_unchecked(CStr::from_ptr(extra.initial_text).to_bytes())
+                        .encode_utf16()
+                        .take(swkbd.max_text_len as _)
+                        .chain(once(0));
 
                 let mut initial_text_cursor = SWKBD_SHARED_MEM.cast::<u16>();
 
@@ -803,17 +803,16 @@ impl SoftwareKeyboard {
 
         let text16 = if swkbd.text_length > 0 {
             unsafe {
-                widestring::Utf16Str::from_slice(std::slice::from_raw_parts(
+                widestring::Utf16Str::from_slice_unchecked(std::slice::from_raw_parts(
                     SWKBD_SHARED_MEM.add(swkbd.text_offset as _).cast::<u16>(),
                     swkbd.text_length as usize,
                 ))
-                .unwrap()
             }
         } else {
             widestring::utf16str!("")
         };
 
-        buf.extend(text16.encode_utf8());
+        *output = text16.to_string();
 
         if swkbd.save_state_flags & (1 << 0) != 0 {
             unsafe {
@@ -860,20 +859,13 @@ impl SoftwareKeyboard {
         }
 
         let text16 = unsafe {
-            widestring::Utf16Str::from_slice(std::slice::from_raw_parts(
+            widestring::Utf16Str::from_slice_unchecked(std::slice::from_raw_parts(
                 SWKBD_SHARED_MEM.add(swkbd.text_offset as _).cast::<u16>(),
                 swkbd.text_length as usize + 1,
             ))
-            .unwrap()
         };
 
-        let text8 = match String::from_utf8(text16.encode_utf8().collect()) {
-            Ok(s) => s,
-            Err(_) => {
-                svcBreak(USERBREAK_PANIC);
-                unreachable!();
-            }
-        };
+        let text8 = text16.to_string();
 
         let mut retmsg = std::ptr::null();
 

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -5,14 +5,13 @@
 
 use crate::services::{apt::Apt, gfx::Gfx};
 use ctru_sys::{
-    self, aptLaunchLibraryApplet, aptSetMessageCallback, envGetAptAppId, svcCloseHandle,
+    aptLaunchLibraryApplet, aptSetMessageCallback, envGetAptAppId, svcCloseHandle,
     svcCreateMemoryBlock, APT_SendParameter, SwkbdButton, SwkbdDictWord, SwkbdExtra,
     SwkbdLearningData, SwkbdState, SwkbdStatusData, APPID_SOFTWARE_KEYBOARD, APTCMD_MESSAGE,
     NS_APPID,
 };
 
 use bitflags::bitflags;
-use libc;
 
 use std::ffi::{CStr, CString};
 use std::fmt::Display;

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -809,12 +809,12 @@ impl SoftwareKeyboard {
                     SWKBD_SHARED_MEM
                         .add((*swkbd).text_offset as _)
                         .cast::<u16>(),
-                    (*swkbd).text_length as usize + 1,
+                    (*swkbd).text_length as usize,
                 ))
                 .unwrap()
             }
         } else {
-            widestring::utf16str!("\0")
+            widestring::utf16str!("")
         };
 
         buf.extend(text16.encode_utf8());

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -114,7 +114,7 @@ pub enum ButtonConfig {
     LeftMiddleRight = 3,
 }
 
-/// Error returned by an unsuccessful [`SoftwareKeyboard::get_string()`].
+/// Error returned by an unsuccessful [`SoftwareKeyboard::launch()`].
 #[doc(alias = "SwkbdResult")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(i32)]
@@ -266,13 +266,13 @@ impl SoftwareKeyboard {
     /// use ctru::applets::swkbd::SoftwareKeyboard;
     /// let mut keyboard = SoftwareKeyboard::default();
     ///
-    /// let (text, button) = keyboard.get_string(&apt, &gfx)?;
+    /// let (text, button) = keyboard.launch(&apt, &gfx)?;
     /// #
     /// # Ok(())
     /// # }
     /// ```
     #[doc(alias = "swkbdInputText")]
-    pub fn get_string(&mut self, _apt: &Apt, _gfx: &Gfx) -> Result<(String, Button), Error> {
+    pub fn launch(&mut self, _apt: &Apt, _gfx: &Gfx) -> Result<(String, Button), Error> {
         let mut output = String::new();
 
         unsafe {
@@ -608,7 +608,7 @@ impl SoftwareKeyboard {
     ///
     /// Keyboard input is converted from UTF-16 to UTF-8 before being handed to Rust,
     /// so this code point limit does not necessarily equal the max number of UTF-8 code points
-    /// receivable by [`SoftwareKeyboard::get_string()`].
+    /// receivable by [`SoftwareKeyboard::launch()`].
     ///
     /// # Example
     ///

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -687,7 +687,7 @@ impl SoftwareKeyboard {
 
         let mut swkbd_shared_mem_handle = 0;
 
-        if unsafe { SWKBD_SHARED_MEM == std::ptr::null_mut() } {
+        if unsafe { SWKBD_SHARED_MEM.is_null() } {
             (*swkbd).result = SWKBD_OUTOFMEM;
             return SWKBD_BUTTON_NONE;
         }
@@ -711,7 +711,7 @@ impl SoftwareKeyboard {
         }
 
         // Copy stuff to shared mem
-        if extra.initial_text != std::ptr::null() {
+        if !extra.initial_text.is_null() {
             (*swkbd).initial_text_offset = 0;
 
             let utf16_iter = CStr::from_ptr(extra.initial_text)
@@ -728,7 +728,7 @@ impl SoftwareKeyboard {
             }
         }
 
-        if extra.dict != std::ptr::null() {
+        if !extra.dict.is_null() {
             (*swkbd).dict_offset = dict_off as _;
             unsafe {
                 libc::memcpy(
@@ -890,7 +890,7 @@ impl SoftwareKeyboard {
             text8.len(),
         ) as _;
 
-        let retmsg = if retmsg != std::ptr::null() {
+        let retmsg = if !retmsg.is_null() {
             unsafe {
                 let len = libc::strlen(retmsg);
                 std::str::from_utf8_unchecked(std::slice::from_raw_parts(retmsg, len + 1))

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -281,7 +281,7 @@ impl SoftwareKeyboard {
                 (self as *mut Self).cast(),
             );
 
-            match Self::swkbd_input_text(self.state.as_mut(), &mut output) {
+            match Self::swkbd_input_text(&mut self.state, &mut output) {
                 ctru_sys::SWKBD_BUTTON_NONE => Err(self.state.result.into()),
                 ctru_sys::SWKBD_BUTTON_LEFT => Ok((output, Button::Left)),
                 ctru_sys::SWKBD_BUTTON_MIDDLE => Ok((output, Button::Middle)),
@@ -631,7 +631,9 @@ impl SoftwareKeyboard {
     // A reimplementation of `swkbdInputText` from `libctru/source/applets/swkbd.c`. Allows us to
     // get text from the software keyboard and put it directly into a `String` without requiring
     // an intermediate fixed-size buffer
-    fn swkbd_input_text(swkbd: &mut SwkbdState, output: &mut String) -> SwkbdButton {
+    //
+    // SAFETY: `swkbd` must be initialized by `swkbdInit` before calling this function.
+    unsafe fn swkbd_input_text(swkbd: &mut SwkbdState, output: &mut String) -> SwkbdButton {
         use ctru_sys::{
             MEMPERM_READ, MEMPERM_WRITE, R_FAILED, SWKBD_BUTTON_LEFT, SWKBD_BUTTON_MIDDLE,
             SWKBD_BUTTON_NONE, SWKBD_BUTTON_RIGHT, SWKBD_D0_CLICK, SWKBD_D1_CLICK0,

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -606,7 +606,7 @@ impl SoftwareKeyboard {
     ///
     /// Keyboard input is converted from UTF-16 to UTF-8 before being handed to Rust,
     /// so this code point limit does not necessarily equal the max number of UTF-8 code points
-    /// receivable by [`SoftwareKeyboard::get_string()`] and [`SoftwareKeyboard::write_exact()`].
+    /// receivable by [`SoftwareKeyboard::get_string()`].
     ///
     /// # Example
     ///

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -733,10 +733,10 @@ impl SoftwareKeyboard {
         if !extra.dict.is_null() {
             swkbd.dict_offset = dict_off as _;
             unsafe {
-                libc::memcpy(
-                    SWKBD_SHARED_MEM.add(dict_off),
-                    extra.dict.cast(),
-                    std::mem::size_of::<SwkbdDictWord>() * swkbd.dict_word_count as usize,
+                std::ptr::copy_nonoverlapping(
+                    extra.dict,
+                    SWKBD_SHARED_MEM.add(dict_off).cast(),
+                    swkbd.dict_word_count as _,
                 )
             };
         }
@@ -744,10 +744,10 @@ impl SoftwareKeyboard {
         if swkbd.initial_status_offset >= 0 {
             swkbd.initial_status_offset = status_off as _;
             unsafe {
-                libc::memcpy(
-                    SWKBD_SHARED_MEM.add(status_off),
-                    extra.status_data.cast(),
-                    std::mem::size_of::<SwkbdStatusData>(),
+                std::ptr::copy_nonoverlapping(
+                    extra.status_data,
+                    SWKBD_SHARED_MEM.add(status_off).cast(),
+                    1,
                 )
             };
         }
@@ -755,10 +755,10 @@ impl SoftwareKeyboard {
         if swkbd.initial_learning_offset >= 0 {
             swkbd.initial_learning_offset = learning_off as _;
             unsafe {
-                libc::memcpy(
-                    SWKBD_SHARED_MEM.add(learning_off),
-                    extra.learning_data.cast(),
-                    std::mem::size_of::<SwkbdLearningData>(),
+                std::ptr::copy_nonoverlapping(
+                    extra.learning_data,
+                    SWKBD_SHARED_MEM.add(learning_off).cast(),
+                    1,
                 )
             };
         }
@@ -771,11 +771,7 @@ impl SoftwareKeyboard {
 
         // Launch swkbd
         unsafe {
-            libc::memset(
-                std::ptr::addr_of_mut!(swkbd.__bindgen_anon_1.reserved).cast(),
-                0,
-                swkbd.__bindgen_anon_1.reserved.len(),
-            );
+            swkbd.__bindgen_anon_1.reserved.fill(0);
 
             if extra.callback.is_some() {
                 aptSetMessageCallback(
@@ -821,20 +817,20 @@ impl SoftwareKeyboard {
 
         if swkbd.save_state_flags & (1 << 0) != 0 {
             unsafe {
-                libc::memcpy(
-                    extra.status_data.cast(),
-                    SWKBD_SHARED_MEM.add(swkbd.status_offset as _),
-                    std::mem::size_of::<SwkbdStatusData>(),
+                std::ptr::copy_nonoverlapping(
+                    SWKBD_SHARED_MEM.add(swkbd.status_offset as _).cast(),
+                    extra.status_data,
+                    1,
                 )
             };
         }
 
         if swkbd.save_state_flags & (1 << 1) != 0 {
             unsafe {
-                libc::memcpy(
-                    extra.learning_data.cast(),
-                    SWKBD_SHARED_MEM.add(swkbd.learning_offset as _),
-                    std::mem::size_of::<SwkbdLearningData>(),
+                std::ptr::copy_nonoverlapping(
+                    SWKBD_SHARED_MEM.add(swkbd.learning_offset as _).cast(),
+                    extra.learning_data,
+                    1,
                 )
             };
         }

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -890,7 +890,11 @@ impl SoftwareKeyboard {
         let callback_msg = &mut swkbd.callback_msg;
 
         if swkbd.callback_result > SWKBD_CALLBACK_OK as _ {
-            for (idx, ch) in retmsg.encode_utf16().take(callback_msg.len()).enumerate() {
+            for (idx, ch) in retmsg
+                .encode_utf16()
+                .take(callback_msg.len() - 1)
+                .enumerate()
+            {
                 callback_msg[idx] = ch;
             }
         } else {

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -869,12 +869,14 @@ impl SoftwareKeyboard {
 
         let mut retmsg = std::ptr::null();
 
-        swkbd.callback_result = extra.callback.unwrap()(
-            extra.callback_user,
-            &mut retmsg,
-            text8.as_ptr(),
-            text8.len(),
-        ) as _;
+        if let Some(cb) = extra.callback {
+            swkbd.callback_result = cb(
+                extra.callback_user,
+                &mut retmsg,
+                text8.as_ptr(),
+                text8.len(),
+            ) as _
+        };
 
         let retmsg = if !retmsg.is_null() {
             unsafe {

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -213,7 +213,8 @@ bitflags! {
     }
 }
 
-// Internal book-keeping struct used to send data to `aptSetMessageCallback` when calling the software keyboard
+// Internal book-keeping struct used to send data to `aptSetMessageCallback` when calling the software keyboard.
+// We only need this because libctru doesn't keep a pointer to the shared memory block in `SwkbdExtra` for whatever reason
 struct MessageCallbackData {
     extra: *mut SwkbdExtra,
     swkbd_shared_mem_ptr: *mut libc::c_void,
@@ -855,8 +856,7 @@ impl SoftwareKeyboard {
     }
 
     // A reimplementation of `swkbdMessageCallback` from `libctru/source/applets/swkbd.c`.
-    // This is only needed because the original function is private to libctru, so we can't
-    // simply reuse their version
+    // This function sets up and then calls the callback set by `swkbdSetFilterCallback`
     #[deny(unsafe_op_in_unsafe_fn)]
     unsafe extern "C" fn swkbd_message_callback(
         user: *mut libc::c_void,

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -647,13 +647,13 @@ impl SoftwareKeyboard {
         // Calculate shared mem size
         let mut shared_mem_size = 0;
 
-        shared_mem_size +=
-            (std::mem::size_of::<u16>() * (swkbd.max_text_len as usize + 1) + 3) & !3;
+        shared_mem_size += (std::mem::size_of::<u16>() * (swkbd.max_text_len as usize + 1))
+            .next_multiple_of(std::mem::size_of::<usize>());
 
         let dict_off = shared_mem_size;
 
-        shared_mem_size +=
-            (std::mem::size_of::<SwkbdDictWord>() * swkbd.dict_word_count as usize + 3) & !3;
+        shared_mem_size += (std::mem::size_of::<SwkbdDictWord>() * swkbd.dict_word_count as usize)
+            .next_multiple_of(std::mem::size_of::<usize>());
 
         let status_off = shared_mem_size;
 
@@ -681,7 +681,7 @@ impl SoftwareKeyboard {
             shared_mem_size += std::mem::size_of::<SwkbdLearningData>();
         }
 
-        shared_mem_size = (shared_mem_size + 0xFFF) & !0xFFF;
+        shared_mem_size = shared_mem_size.next_multiple_of(0x1000);
 
         swkbd.shared_memory_size = shared_mem_size;
 

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -862,7 +862,7 @@ impl SoftwareKeyboard {
         let text16 = unsafe {
             widestring::Utf16Str::from_slice_unchecked(std::slice::from_raw_parts(
                 SWKBD_SHARED_MEM.add(swkbd.text_offset as _).cast(),
-                swkbd.text_length as usize + 1,
+                swkbd.text_length as _,
             ))
         };
 

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -803,18 +803,16 @@ impl SoftwareKeyboard {
             _ => SWKBD_BUTTON_NONE,
         };
 
-        let text16 = if swkbd.text_length > 0 {
-            unsafe {
+        if swkbd.text_length > 0 {
+            let text16 = unsafe {
                 widestring::Utf16Str::from_slice_unchecked(std::slice::from_raw_parts(
-                    SWKBD_SHARED_MEM.add(swkbd.text_offset as _).cast::<u16>(),
-                    swkbd.text_length as usize,
+                    SWKBD_SHARED_MEM.add(swkbd.text_offset as _).cast(),
+                    swkbd.text_length as _,
                 ))
-            }
-        } else {
-            widestring::utf16str!("")
-        };
+            };
 
-        *output = text16.to_string();
+            *output = text16.to_string();
+        }
 
         if swkbd.save_state_flags & (1 << 0) != 0 {
             unsafe {

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -799,7 +799,7 @@ impl SoftwareKeyboard {
 
             aptLaunchLibraryApplet(
                 APPID_SOFTWARE_KEYBOARD,
-                swkbd as *mut _ as *mut _,
+                (swkbd as *mut SwkbdState).cast(),
                 std::mem::size_of::<SwkbdState>(),
                 swkbd_shared_mem_handle,
             );
@@ -920,7 +920,7 @@ impl SoftwareKeyboard {
                 envGetAptAppId(),
                 sender,
                 APTCMD_MESSAGE,
-                swkbd as *mut _ as *mut _,
+                (swkbd as *mut SwkbdState).cast(),
                 std::mem::size_of::<SwkbdState>() as _,
                 0,
             )

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -737,8 +737,8 @@ impl SoftwareKeyboard {
 
                 let mut initial_text_cursor = swkbd_shared_mem_ptr.cast();
 
-                for code_point in utf16_iter {
-                    *initial_text_cursor = code_point;
+                for code_unit in utf16_iter {
+                    *initial_text_cursor = code_unit;
                     initial_text_cursor = initial_text_cursor.add(1);
                 }
             }
@@ -907,12 +907,12 @@ impl SoftwareKeyboard {
 
         let callback_msg = &mut swkbd.callback_msg;
 
-        for (idx, code_point) in retmsg
+        for (idx, code_unit) in retmsg
             .encode_utf16()
             .take(callback_msg.len() - 1)
             .enumerate()
         {
-            callback_msg[idx] = code_point;
+            callback_msg[idx] = code_unit;
         }
 
         let _ = unsafe {


### PR DESCRIPTION
Ever since I first started messing with the software keyboard from Rust, I've always *hated* that libctru's `swkbd` API forces you to use a fixed-size buffer in order to receive string data from the keyboard. We've worked around that restriction by just forcing the user to specify a maximum size for the intermediate text buffer, but I've always hated that solution too. And so I randomly decided it's finally time to do something about it.

However, it turns out that "doing something about it" involves reimplementing both [swkbdInputText](https://github.com/devkitPro/libctru/blob/master/libctru/source/applets/swkbd.c#L170-L272) and [swkbdMessageCallback](https://github.com/devkitPro/libctru/blob/master/libctru/source/applets/swkbd.c#L144-L168) in Rust and handling a whole bunch of gnarly unsafe code ourselves instead of just leaving all of that nonsense to libctru.

Is it worth introducing this much unsafe code just to solve a small API nitpick? Frankly I'm not entirely sure, but I thought I'd throw this out there and see what you guys think.