### PR TITLE
Fix console API issues

### DIFF
--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -143,7 +143,7 @@ impl<'screen> Console<'screen> {
     /// ```
     pub fn exists() -> bool {
         unsafe {
-            let current_console = ctru_sys::consoleSelect(&mut EMPTY_CONSOLE);
+            let current_console = ctru_sys::consoleSelect(std::ptr::addr_of_mut!(EMPTY_CONSOLE));
 
             let res = (*current_console).consoleInitialised;
 
@@ -364,7 +364,7 @@ impl Drop for Console<'_> {
             // the screen, but it won't crash either.
 
             // Get the current console by replacing it with an empty one.
-            let current_console = ctru_sys::consoleSelect(&mut EMPTY_CONSOLE);
+            let current_console = ctru_sys::consoleSelect(std::ptr::addr_of_mut!(EMPTY_CONSOLE));
 
             if std::ptr::eq(current_console, &*self.context) {
                 // Console dropped while selected. We just replaced it with the

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -5,7 +5,7 @@
 //!
 //! Have a look at [`Soc::redirect_to_3dslink()`](crate::services::soc::Soc::redirect_to_3dslink) for a better alternative when debugging applications.
 
-use std::cell::RefMut;
+use std::cell::{RefMut, UnsafeCell};
 use std::default::Default;
 
 use ctru_sys::{consoleClear, consoleInit, consoleSelect, consoleSetWindow, PrintConsole};
@@ -63,7 +63,7 @@ impl<S: Screen + Swap + Flush> ConsoleScreen for S {}
 /// More info in the [`cargo-3ds` docs](https://github.com/rust3ds/cargo-3ds#running-executables).
 #[doc(alias = "PrintConsole")]
 pub struct Console<'screen> {
-    context: Box<PrintConsole>,
+    context: Box<UnsafeCell<PrintConsole>>,
     screen: RefMut<'screen, dyn ConsoleScreen>,
 }
 
@@ -107,9 +107,9 @@ impl<'screen> Console<'screen> {
     /// ```
     #[doc(alias = "consoleInit")]
     pub fn new<S: ConsoleScreen>(screen: RefMut<'screen, S>) -> Self {
-        let mut context = Box::<PrintConsole>::default();
+        let context = Box::<UnsafeCell<PrintConsole>>::default();
 
-        unsafe { consoleInit(screen.as_raw(), context.as_mut()) };
+        unsafe { consoleInit(screen.as_raw(), context.get()) };
 
         Console { context, screen }
     }
@@ -190,7 +190,7 @@ impl<'screen> Console<'screen> {
     #[doc(alias = "consoleSelect")]
     pub fn select(&self) {
         unsafe {
-            consoleSelect(self.context.as_ref() as *const _ as *mut _);
+            consoleSelect(self.context.get());
         }
     }
 
@@ -248,7 +248,7 @@ impl<'screen> Console<'screen> {
 
         unsafe {
             consoleSetWindow(
-                self.context.as_mut(),
+                self.context.get(),
                 x.into(),
                 y.into(),
                 width.into(),
@@ -338,7 +338,10 @@ impl Swap for Console<'_> {
     /// This should be called once per frame at most.
     fn swap_buffers(&mut self) {
         self.screen.swap_buffers();
-        self.context.frameBuffer = self.screen.raw_framebuffer().ptr as *mut u16;
+
+        unsafe {
+            (*self.context.get()).frameBuffer = self.screen.raw_framebuffer().ptr as *mut u16
+        };
     }
 
     fn set_double_buffering(&mut self, enabled: bool) {
@@ -366,7 +369,7 @@ impl Drop for Console<'_> {
             // Get the current console by replacing it with an empty one.
             let current_console = ctru_sys::consoleSelect(std::ptr::addr_of_mut!(EMPTY_CONSOLE));
 
-            if std::ptr::eq(current_console, &*self.context) {
+            if std::ptr::eq(current_console, self.context.get()) {
                 // Console dropped while selected. We just replaced it with the
                 // empty console so nothing more to do.
             } else {


### PR DESCRIPTION
This PR consists of 2 parts. The first change is to use `addr_of_mut!` when getting pointers to the `EMPTY_CONSOLE`, which fixes some warnings about mutable references to `static mut` objects on recent nightlies.

The second change is one I'm making based more on "vibes" than anything, but I've long felt suspicious about the soundness of our `Console` API when it comes to taking references and pointers to the internal `PrintConsole`. For example, we have a number of console APIs that take `&self` even though there are underlying mutations in the `PrintConsole` struct every time a character is written to the screen.

I've never actually run into any problems or strange behavior when dealing with the console, but I suspect that the "proper" way to handle things is to wrap the `PrintConsole` in an `UnsafeCell` so that the compiler won't make assumptions about having unique access to the console state unless we specifically tell it to do so, and so I've made that change in this PR too.

It's possible that this change might be overly paranoid, but I'm not sure there's any harm in being paranoid in this particular way either. Either way, feel free to let me know what you guys think about the issue too.