### PR TITLE
Improve SoftwareKeyboard::set_filter_callback

### DIFF
--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -19,7 +19,7 @@ fn main() {
     // Custom filter callback to handle the given input.
     // Using this callback it's possible to integrate the applet
     // with custom error messages when the input is incorrect.
-    keyboard.set_filter_callback(Some(|text| {
+    keyboard.set_filter_callback(Some(Box::new(|text| {
         if text.contains("boo") {
             return (
                 CallbackResult::Retry,
@@ -28,7 +28,7 @@ fn main() {
         }
 
         (CallbackResult::Ok, None)
-    }));
+    })));
 
     println!("Press A to enter some text or press Start to exit.");
 

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -5,8 +5,6 @@
 use ctru::applets::swkbd::{Button, CallbackResult, SoftwareKeyboard};
 use ctru::prelude::*;
 
-use std::ffi::CString;
-
 fn main() {
     let apt = Apt::new().unwrap();
     let mut hid = Hid::new().unwrap();
@@ -21,17 +19,16 @@ fn main() {
     // Custom filter callback to handle the given input.
     // Using this callback it's possible to integrate the applet
     // with custom error messages when the input is incorrect.
-    keyboard.set_filter_callback(Some(Box::new(|str| {
-        // The string is guaranteed to contain valid Unicode text, so we can safely unwrap and use it as a normal `&str`.
-        if str.to_str().unwrap().contains("boo") {
+    keyboard.set_filter_callback(Some(|text| {
+        if text.contains("boo") {
             return (
                 CallbackResult::Retry,
-                Some(CString::new("Ah, you scared me!").unwrap()),
+                Some(String::from("Ah, you scared me!")),
             );
         }
 
         (CallbackResult::Ok, None)
-    })));
+    }));
 
     println!("Press A to enter some text or press Start to exit.");
 

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -5,6 +5,8 @@
 use ctru::applets::swkbd::{Button, CallbackResult, SoftwareKeyboard};
 use ctru::prelude::*;
 
+use std::ffi::CString;
+
 fn main() {
     let apt = Apt::new().unwrap();
     let mut hid = Hid::new().unwrap();
@@ -23,7 +25,7 @@ fn main() {
         if text.contains("boo") {
             return (
                 CallbackResult::Retry,
-                Some(String::from("Ah, you scared me!")),
+                Some(CString::new("Ah, you scared me!").unwrap()),
             );
         }
 

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -14,7 +14,7 @@ use std::fmt::Display;
 use std::iter::once;
 use std::str;
 
-type CallbackFunction = dyn Fn(&str) -> (CallbackResult, Option<String>);
+type CallbackFunction = dyn Fn(&str) -> (CallbackResult, Option<CString>);
 
 /// Configuration structure to setup the Software Keyboard applet.
 #[doc(alias = "SwkbdState")]
@@ -399,6 +399,7 @@ impl SoftwareKeyboard {
     /// # fn main() {
     /// #
     /// use std::borrow::Cow;
+    /// use std::ffi::CString;
     /// use ctru::applets::swkbd::{SoftwareKeyboard, CallbackResult};
     ///
     /// let mut keyboard = SoftwareKeyboard::default();
@@ -407,7 +408,7 @@ impl SoftwareKeyboard {
     ///     if text.contains("boo") {
     ///         return (
     ///             CallbackResult::Retry,
-    ///             Some(String::from("Ah, you scared me!")),
+    ///             Some(CString::new("Ah, you scared me!").unwrap()),
     ///         );
     ///     }
     ///
@@ -442,8 +443,6 @@ impl SoftwareKeyboard {
                     // Due to how `libctru` operates, the user is expected to keep the error message alive until
                     // the end of the Software Keyboard prompt. We ensure that happens by saving it within the configuration.
                     if let Some(error_message) = error_message {
-                        let error_message = CString::from_vec_unchecked(error_message.into_bytes());
-
                         *pp_message = error_message.as_ptr();
 
                         this.error_message = Some(error_message);


### PR DESCRIPTION
We don't need to box the user's closure, and we can let the user deal with normal Rust strings while handling CString conversion internally too.