### PR TITLE
Implement low hanging apt sleep/homemenu functions and chainloader

### DIFF
--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -51,6 +51,11 @@ impl<'a> Title<'a> {
     pub fn version(&self) -> u16 {
         self.version
     }
+
+    /// Returns this title's media type
+    pub fn media_type(&self) -> MediaType {
+        self.mediatype
+    }
 }
 
 /// Handle to the Application Manager service.

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -98,9 +98,7 @@ impl Apt {
     /// You can set whether the console is allowed to sleep with [Apt::set_sleep_allowed].
     #[doc(alias = "aptIsSleepAllowed")]
     pub fn is_sleep_allowed(&mut self) -> bool {
-        unsafe {
-            ctru_sys::aptIsSleepAllowed()
-        }
+        unsafe { ctru_sys::aptIsSleepAllowed() }
     }
 
     /// Set if the console is allowed to enter the home menu.
@@ -114,21 +112,17 @@ impl Apt {
     }
 
     /// Check if the console is allowed to enter the home menu.
-    /// 
+    ///
     /// You can set whether the console is allowed to enter the home menu with [Apt::set_home_allowed].
     #[doc(alias = "aptIsHomeAllowed")]
     pub fn is_home_allowed(&mut self) -> bool {
-        unsafe {
-            ctru_sys::aptIsHomeAllowed()
-        }
+        unsafe { ctru_sys::aptIsHomeAllowed() }
     }
 
     /// Immediately jumps to the home menu.
     #[doc(alias = "aptIsHomeAllowed")]
     pub fn jump_to_home_menu(&mut self) {
-        unsafe {
-            ctru_sys::aptJumpToHomeMenu()
-        }
+        unsafe { ctru_sys::aptJumpToHomeMenu() }
     }
 }
 

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -120,7 +120,7 @@ impl Apt {
     }
 
     /// Immediately jumps to the home menu.
-    #[doc(alias = "aptIsHomeAllowed")]
+    #[doc(alias = "aptJumpToHomeMenu")]
     pub fn jump_to_home_menu(&mut self) {
         unsafe { ctru_sys::aptJumpToHomeMenu() }
     }
@@ -159,19 +159,19 @@ impl<'a> Chainloader<'a> {
 
     /// Configures the chainloader to launch a specific application.
     #[doc(alias = "aptSetChainloader")]
-    pub fn set_chainloader(&mut self, title: &super::am::Title<'_>) {
+    pub fn set(&mut self, title: &super::am::Title<'_>) {
         unsafe { ctru_sys::aptSetChainloader(title.id(), title.media_type() as u8) }
     }
 
     /// Configures the chainloader to launch the previous application.
     #[doc(alias = "aptSetChainloaderToCaller")]
-    pub fn set_chainloader_to_caller(&mut self) {
+    pub fn set_to_caller(&mut self) {
         unsafe { ctru_sys::aptSetChainloaderToCaller() }
     }
 
     /// Configures the chainloader to relaunch the current application (i.e. soft-reset)
     #[doc(alias = "aptSetChainloaderToSelf")]
-    pub fn set_chainloader_to_self(&mut self) {
+    pub fn set_to_self(&mut self) {
         unsafe { ctru_sys::aptSetChainloaderToSelf() }
     }
 }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -82,6 +82,54 @@ impl Apt {
             Ok(())
         }
     }
+
+    /// Set if the console is allowed to enter sleep mode.
+    ///
+    /// You can check whether the console is allowed to sleep with [Apt::is_sleep_allowed].
+    #[doc(alias = "aptSetSleepAllowed")]
+    pub fn set_sleep_allowed(&mut self, allowed: bool) {
+        unsafe {
+            ctru_sys::aptSetSleepAllowed(allowed);
+        }
+    }
+
+    /// Check if the console is allowed to enter sleep mode.
+    ///
+    /// You can set whether the console is allowed to sleep with [Apt::set_sleep_allowed].
+    #[doc(alias = "aptIsSleepAllowed")]
+    pub fn is_sleep_allowed(&mut self) -> bool {
+        unsafe {
+            ctru_sys::aptIsSleepAllowed()
+        }
+    }
+
+    /// Set if the console is allowed to enter the home menu.
+    ///
+    /// You can check whether the console is allowed to enter the home menu with [Apt::is_home_allowed].
+    #[doc(alias = "aptSetHomeAllowed")]
+    pub fn set_home_allowed(&mut self, allowed: bool) {
+        unsafe {
+            ctru_sys::aptSetHomeAllowed(allowed);
+        }
+    }
+
+    /// Check if the console is allowed to enter the home menu.
+    /// 
+    /// You can set whether the console is allowed to enter the home menu with [Apt::set_home_allowed].
+    #[doc(alias = "aptIsHomeAllowed")]
+    pub fn is_home_allowed(&mut self) -> bool {
+        unsafe {
+            ctru_sys::aptIsHomeAllowed()
+        }
+    }
+
+    /// Immediately jumps to the home menu.
+    #[doc(alias = "aptIsHomeAllowed")]
+    pub fn jump_to_home_menu(&mut self) {
+        unsafe {
+            ctru_sys::aptJumpToHomeMenu()
+        }
+    }
 }
 
 impl Drop for Apt {

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -97,7 +97,7 @@ impl Apt {
     ///
     /// You can set whether the console is allowed to sleep with [Apt::set_sleep_allowed].
     #[doc(alias = "aptIsSleepAllowed")]
-    pub fn is_sleep_allowed(&mut self) -> bool {
+    pub fn is_sleep_allowed(&self) -> bool {
         unsafe { ctru_sys::aptIsSleepAllowed() }
     }
 
@@ -115,7 +115,7 @@ impl Apt {
     ///
     /// You can set whether the console is allowed to enter the home menu with [Apt::set_home_allowed].
     #[doc(alias = "aptIsHomeAllowed")]
-    pub fn is_home_allowed(&mut self) -> bool {
+    pub fn is_home_allowed(&self) -> bool {
         unsafe { ctru_sys::aptIsHomeAllowed() }
     }
 

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -159,7 +159,7 @@ impl<'a> Chainloader<'a> {
 
     /// Configures the chainloader to launch a specific application.
     ///
-    /// See also [super::am::Title]
+    /// See also [`Title`](crate::services::am::Title]
     #[doc(alias = "aptSetChainloader")]
     pub fn set(&mut self, title: &super::am::Title<'_>) {
         unsafe { ctru_sys::aptSetChainloader(title.id(), title.media_type() as u8) }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -158,6 +158,8 @@ impl<'a> Chainloader<'a> {
     }
 
     /// Configures the chainloader to launch a specific application.
+    ///
+    /// See also [super::am::Title]
     #[doc(alias = "aptSetChainloader")]
     pub fn set(&mut self, title: &super::am::Title<'_>) {
         unsafe { ctru_sys::aptSetChainloader(title.id(), title.media_type() as u8) }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -132,3 +132,44 @@ impl Drop for Apt {
         unsafe { ctru_sys::aptExit() };
     }
 }
+
+pub struct Chainloader<'a> {
+    _apt: &'a Apt,
+}
+
+impl<'a> Chainloader<'a> {
+    /// Gets a handle to the chainloader
+    pub fn new(apt: &'a Apt) -> Self {
+        Self { _apt: apt }
+    }
+
+    /// Checks if the chainloader is set
+    #[doc(alias = "aptIsChainload")]
+    pub fn is_set(&mut self) {
+        //unsafe { ctru_sys::aptIsChainload() }
+    }
+
+    /// Clears the chainloader state.
+    #[doc(alias = "aptClearChainloader")]
+    pub fn clear(&mut self) {
+        unsafe { ctru_sys::aptClearChainloader() }
+    }
+
+    /// Configures the chainloader to launch a specific application.
+    #[doc(alias = "aptSetChainloader")]
+    pub fn set_chainloader(&mut self, title: &super::am::Title<'_>) {
+        unsafe { ctru_sys::aptSetChainloader(title.id(), title.media_type() as u8) }
+    }
+
+    /// Configures the chainloader to launch the previous application.
+    #[doc(alias = "aptSetChainloaderToCaller")]
+    pub fn set_chainloader_to_caller(&mut self) {
+        unsafe { ctru_sys::aptSetChainloaderToCaller() }
+    }
+
+    /// Configures the chainloader to relaunch the current application (i.e. soft-reset)
+    #[doc(alias = "aptSetChainloaderToSelf")]
+    pub fn set_chainloader_to_self(&mut self) {
+        unsafe { ctru_sys::aptSetChainloaderToSelf() }
+    }
+}

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -133,6 +133,7 @@ impl Drop for Apt {
     }
 }
 
+/// Can launch other applications when the current one exits.
 pub struct Chainloader<'a> {
     _apt: &'a Apt,
 }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -146,8 +146,9 @@ impl<'a> Chainloader<'a> {
 
     /// Checks if the chainloader is set
     #[doc(alias = "aptIsChainload")]
-    pub fn is_set(&mut self) {
-        //unsafe { ctru_sys::aptIsChainload() }
+    pub fn is_set(&self) -> bool {
+        // static funtion not exported
+        unsafe { (ctru_sys::envGetSystemRunFlags() & ctru_sys::RUNFLAG_APTCHAINLOAD) != 0 }
     }
 
     /// Clears the chainloader state.


### PR DESCRIPTION
Saw that these weren't added yet, although they're very simple.

## TLDR, Implemented
- [x] `aptSetSleepAllowed`
- [x] `aptIsSleepAllowed`
- [x] `aptSetHomeAllowed`
- [x] `aptIsHomeAllowed`
- [x] `aptJumpToHomeMenu`
- [x] chainloader stuff
- [ ] applist stuff