### PR TITLE
Add error applet support + error applet panic hook

### DIFF
--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -88,12 +88,16 @@ impl PopUp {
     }
 }
 
-/// Sets a custom panic hook that uses the error applet to display panic messages. You can also choose to have the
-/// previously registered panic hook called along with the error applet message, which can be useful if you want
-/// to use input redirection to display panic messages over `3dslink` or `GDB`.
+/// Sets a custom [panic hook](https://doc.rust-lang.org/std/panic/fn.set_hook.html) that uses the error applet to display panic messages.
 ///
-/// If the `Gfx` service is not initialized during a panic, the error applet will not be displayed and the old
+/// You can also choose to have the previously registered panic hook called along with the error applet message, which can be useful
+/// if you want to use output redirection to display panic messages over `3dslink` or `GDB`.
+///
+/// If the [`Gfx`] service is not initialized during a panic, the error applet will not be displayed and the old
 /// panic hook will be called.
+///
+/// You can use [`std::panic::take_hook`](https://doc.rust-lang.org/std/panic/fn.take_hook.html) to unregister the panic hook
+/// set by this function.
 pub fn set_panic_hook(call_old_hook: bool) {
     use crate::services::gfx::GFX_ACTIVE;
     use std::sync::TryLockError;

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -89,19 +89,16 @@ impl PopUp {
 }
 
 /// Sets a custom panic hook that uses the error applet to display panic messages. You can also choose to have the
-/// default panic hook called to print the message over stderr.
+/// previously registered panic hook called along with the error applet message, which can be useful if you want
+/// to use input redirection to display panic messages over `3dslink` or `GDB`.
 ///
-/// If the `Gfx` service is not initialized during a panic, the error applet will not be displayed and the default
-/// hook will be called.
-pub fn set_panic_hook(call_default_hook: bool) {
+/// If the `Gfx` service is not initialized during a panic, the error applet will not be displayed and the old
+/// panic hook will be called.
+pub fn set_panic_hook(call_old_hook: bool) {
     use crate::services::gfx::GFX_ACTIVE;
     use std::sync::TryLockError;
 
-    // Ensure we get the default hook instead of a previously registered user hook.
-    let default_hook = {
-        let _ = std::panic::take_hook();
-        std::panic::take_hook()
-    };
+    let old_hook = std::panic::take_hook();
 
     std::panic::set_hook(Box::new(move |panic_info| {
         let thread = std::thread::current();
@@ -111,8 +108,8 @@ pub fn set_panic_hook(call_default_hook: bool) {
         // If we get a `WouldBlock` error, we know that the `Gfx` service has been initialized.
         // Otherwise fallback to printing over stderr.
         if let (Err(TryLockError::WouldBlock), Ok(_apt)) = (GFX_ACTIVE.try_lock(), Apt::new()) {
-            if call_default_hook {
-                default_hook(panic_info);
+            if call_old_hook {
+                old_hook(panic_info);
             }
 
             let payload = format!("thread '{name}' {panic_info}");
@@ -125,7 +122,7 @@ pub fn set_panic_hook(call_default_hook: bool) {
                 popup.launch_unchecked();
             }
         } else {
-            default_hook(panic_info);
+            old_hook(panic_info);
         }
     }));
 }

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -108,25 +108,22 @@ pub fn set_panic_hook(use_stderr: bool) {
 
         // If we get a `WouldBlock` error, we know that the `Gfx` service has been initialized.
         // Otherwise fallback to printing over stderr.
-        match GFX_ACTIVE.try_lock() {
-            Err(TryLockError::WouldBlock) => {
-                if use_stderr {
-                    print_to_stderr(name, panic_info);
-                }
-
-                let payload = format!("thread '{name}' {panic_info}");
-
-                let mut popup = PopUp::new(Kind::Top);
-
-                popup.set_text(&payload);
-
-                unsafe {
-                    popup.launch_unchecked();
-                }
-            }
-            _ => {
+        if let Err(TryLockError::WouldBlock) = GFX_ACTIVE.try_lock() {
+            if use_stderr {
                 print_to_stderr(name, panic_info);
             }
+
+            let payload = format!("thread '{name}' {panic_info}");
+
+            let mut popup = PopUp::new(Kind::Top);
+
+            popup.set_text(&payload);
+
+            unsafe {
+                popup.launch_unchecked();
+            }
+        } else {
+            print_to_stderr(name, panic_info);
         }
     }));
 

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -100,15 +100,13 @@ pub fn set_panic_hook(use_stderr: bool) {
     use std::sync::TryLockError;
 
     std::panic::set_hook(Box::new(move |panic_info| {
-        let _apt = Apt::new();
-
         let thread = std::thread::current();
 
         let name = thread.name().unwrap_or("<unnamed>");
 
         // If we get a `WouldBlock` error, we know that the `Gfx` service has been initialized.
         // Otherwise fallback to printing over stderr.
-        if let Err(TryLockError::WouldBlock) = GFX_ACTIVE.try_lock() {
+        if let (Err(TryLockError::WouldBlock), Ok(_apt)) = (GFX_ACTIVE.try_lock(), Apt::new()) {
             if use_stderr {
                 print_to_stderr(name, panic_info);
             }

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -1,0 +1,56 @@
+//! Error applet
+//!
+//! This applet displays error text as a pop-up message on the lower screen.
+#![doc(alias = "Error")]
+
+use crate::services::{apt::Apt, gfx::Gfx};
+
+use ctru_sys::errorConf;
+
+/// Configuration struct to set up the Error applet.
+#[doc(alias = "errorConf")]
+pub struct ErrorApplet {
+    state: Box<errorConf>,
+}
+
+/// The kind of error applet to display.
+#[doc(alias = "errorType")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Kind {
+    /// Error text is centered in the error applet window.
+    Center = ctru_sys::ERROR_TEXT,
+    /// Error text starts at the top of the error applet window.
+    Top = ctru_sys::ERROR_TEXT_WORD_WRAP,
+}
+
+impl ErrorApplet {
+    /// Initialize the error applet with the provided text kind.
+    #[doc(alias = "errorInit")]
+    pub fn new(kind: Kind) -> Self {
+        let mut state = Box::<errorConf>::default();
+
+        unsafe { ctru_sys::errorInit(state.as_mut(), kind as _, 0) };
+
+        Self { state }
+    }
+
+    /// Sets the error text to display.
+    #[doc(alias = "errorText")]
+    pub fn set_text(&mut self, text: &str) {
+        for (idx, code_unit) in text
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .take(self.state.Text.len() - 1)
+            .enumerate()
+        {
+            self.state.Text[idx] = code_unit;
+        }
+    }
+
+    /// Launches the error applet.
+    #[doc(alias = "errorDisp")]
+    pub fn launch(&mut self, _apt: &Apt, _gfx: &Gfx) {
+        unsafe { ctru_sys::errorDisp(self.state.as_mut()) }
+    }
+}

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -82,7 +82,9 @@ impl PopUp {
 /// Sets a custom panic hook that uses the error applet to display panic messages. You can also choose to have
 /// messages printed over stderr along with the pop-up display.
 ///
-/// SAFETY: The error applet requires that both the [`Apt`] and [`Gfx`] services are active whenever it launches.
+/// # Safety
+///
+/// The error applet requires that both the [`Apt`] and [`Gfx`] services are active whenever it launches.
 /// By calling this function, you promise that you will keep those services alive until either the program ends or
 /// you unregister this hook with [`std::panic::take_hook`](https://doc.rust-lang.org/std/panic/fn.take_hook.html).
 pub unsafe fn set_panic_hook(use_stderr: bool) {

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -61,8 +61,8 @@ impl PopUp {
     pub fn set_text(&mut self, text: &str) {
         for (idx, code_unit) in text
             .encode_utf16()
-            .chain(std::iter::once(0))
             .take(self.state.Text.len() - 1)
+            .chain(std::iter::once(0))
             .enumerate()
         {
             self.state.Text[idx] = code_unit;

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -77,6 +77,15 @@ impl PopUp {
             _ => Err(Error::Unknown),
         }
     }
+
+    /// Launches the error applet without requiring an [`Apt`] or [`Gfx`] handle.
+    ///
+    /// # Safety
+    ///
+    /// Causes undefined behavior if the aforementioned services are not actually active when the applet launches.
+    unsafe fn launch_unchecked(&mut self) {
+        unsafe { ctru_sys::errorDisp(self.state.as_mut()) };
+    }
 }
 
 /// Sets a custom panic hook that uses the error applet to display panic messages. You can also choose to have
@@ -104,7 +113,7 @@ pub unsafe fn set_panic_hook(use_stderr: bool) {
         }
 
         unsafe {
-            ctru_sys::errorDisp(popup.state.as_mut());
+            popup.launch_unchecked();
         }
     }))
 }

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -55,8 +55,8 @@ impl PopUp {
     ///
     /// # Notes
     ///
-    /// Messages that are too large will be truncated. The exact number of characters displayed can vary depending on factors such as
-    /// the length of individual words in the message and the chosen word wrap setting.
+    /// The text will be converted to UTF-16 for display with the applet, and the message will be truncated if it exceeds
+    /// 1900 UTF-16 code units in length after conversion.
     #[doc(alias = "errorText")]
     pub fn set_text(&mut self, text: &str) {
         for (idx, code_unit) in text
@@ -105,9 +105,6 @@ impl PopUp {
 /// # Notes
 ///
 /// * If the [`Gfx`] service is not initialized during a panic, the error applet will not be displayed and the old panic hook will be called.
-///
-/// * As mentioned in [`PopUp::set_text`], the error applet can only display a finite number of characters and so panic messages that are too long
-/// can potentially end up being truncated. Consider using this hook along with the default hook so that you can capture full panic messages via stderr.
 pub fn set_panic_hook(call_old_hook: bool) {
     use crate::services::gfx::GFX_ACTIVE;
     use std::sync::TryLockError;

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -1,15 +1,13 @@
 //! Error applet
 //!
 //! This applet displays error text as a pop-up message on the lower screen.
-#![doc(alias = "Error")]
-
 use crate::services::{apt::Apt, gfx::Gfx};
 
 use ctru_sys::errorConf;
 
 /// Configuration struct to set up the Error applet.
 #[doc(alias = "errorConf")]
-pub struct ErrorApplet {
+pub struct PopUp {
     state: Box<errorConf>,
 }
 

--- a/ctru-rs/src/applets/mod.rs
+++ b/ctru-rs/src/applets/mod.rs
@@ -8,5 +8,6 @@
 //!
 //! Applets block execution of the thread that launches them as long as the user doesn't close the applet.
 
+pub mod error;
 pub mod mii_selector;
 pub mod swkbd;

--- a/ctru-rs/src/services/gfx.rs
+++ b/ctru-rs/src/services/gfx.rs
@@ -239,7 +239,7 @@ pub struct Gfx {
     _service_handler: ServiceReference,
 }
 
-static GFX_ACTIVE: Mutex<()> = Mutex::new(());
+pub(crate) static GFX_ACTIVE: Mutex<()> = Mutex::new(());
 
 impl Gfx {
     /// Initialize a new default service handle.

--- a/ctru-sys/build.rs
+++ b/ctru-sys/build.rs
@@ -79,6 +79,8 @@ fn main() {
         .blocklist_type("u(8|16|32|64)")
         .blocklist_type("__builtin_va_list")
         .blocklist_type("__va_list")
+        .blocklist_type("errorReturnCode")
+        .blocklist_type("errorScreenFlag")
         .opaque_type("MiiData")
         .derive_default(true)
         .wrap_static_fns(true)

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -16,6 +16,22 @@
 pub mod result;
 pub use result::*;
 
+// Fun fact: bindgen can and will generate enum values of the wrong size, and if a generated struct contains fields
+// using those values, then that struct will have the wrong size and field offsets too. To fix that problem,
+// you have to blocklist the enum type in bindgen and manually define it with the proper data type.
+pub const ERROR_UNKNOWN: errorReturnCode = -1;
+pub const ERROR_NONE: errorReturnCode = 0;
+pub const ERROR_SUCCESS: errorReturnCode = 1;
+pub const ERROR_NOT_SUPPORTED: errorReturnCode = 2;
+pub const ERROR_HOME_BUTTON: errorReturnCode = 10;
+pub const ERROR_SOFTWARE_RESET: errorReturnCode = 11;
+pub const ERROR_POWER_BUTTON: errorReturnCode = 12;
+pub type errorReturnCode = libc::c_schar;
+
+pub const ERROR_NORMAL: errorScreenFlag = 0;
+pub const ERROR_STEREO: errorScreenFlag = 1;
+pub type errorScreenFlag = libc::c_char;
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 /// In lieu of a proper errno function exposed by libc

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -21,6 +21,7 @@ pub use result::*;
 // Libctru's `errorConf` struct contains two enums that depend on this narrowing property for size and alignment purposes,
 // and since `bindgen` generates all enums with `c_int` sizing, we have to blocklist those types and manually define them
 // here with the proper size.
+pub type errorReturnCode = libc::c_schar;
 pub const ERROR_UNKNOWN: errorReturnCode = -1;
 pub const ERROR_NONE: errorReturnCode = 0;
 pub const ERROR_SUCCESS: errorReturnCode = 1;
@@ -28,11 +29,10 @@ pub const ERROR_NOT_SUPPORTED: errorReturnCode = 2;
 pub const ERROR_HOME_BUTTON: errorReturnCode = 10;
 pub const ERROR_SOFTWARE_RESET: errorReturnCode = 11;
 pub const ERROR_POWER_BUTTON: errorReturnCode = 12;
-pub type errorReturnCode = libc::c_schar;
 
+pub type errorScreenFlag = libc::c_char;
 pub const ERROR_NORMAL: errorScreenFlag = 0;
 pub const ERROR_STEREO: errorScreenFlag = 1;
-pub type errorScreenFlag = libc::c_char;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -16,9 +16,11 @@
 pub mod result;
 pub use result::*;
 
-// Fun fact: bindgen can and will generate enum values of the wrong size, and if a generated struct contains fields
-// using those values, then that struct will have the wrong size and field offsets too. To fix that problem,
-// you have to blocklist the enum type in bindgen and manually define it with the proper data type.
+// Fun fact: C compilers are allowed to represent enums as the smallest integer type that can hold all of its variants,
+// meaning that enums are allowed to be the size of a `c_short` or a `c_char` rather than the size of a `c_int`.
+// Libctru's `errorConf` struct contains two enums that depend on this narrowing property for size and alignment purposes,
+// and since `bindgen` generates all enums with `c_int` sizing, we have to blocklist those types and manually define them
+// here with the proper size.
 pub const ERROR_UNKNOWN: errorReturnCode = -1;
 pub const ERROR_NONE: errorReturnCode = 0;
 pub const ERROR_SUCCESS: errorReturnCode = 1;


### PR DESCRIPTION
Adds support for the [error applet](https://libctru.devkitpro.org/error_8h.html), which is a simple applet that lets you display error text in a pop-up window on the bottom screen.

The applet is also capable of launching the EULA registration dialogue, as well as "infrastructure communications-related error messages" via error codes of a completely unspecified nature, but I've opted not to support either of these functions. The applet also supports changing the language of the "An error has occurred" header text at the top of the applet, but I don't think it's worth including that functionality either since it defaults to your system's preferred language anyway.

The real fun part about this PR was discovering that Bindgen was generating the `errorConf` struct with the wrong size and field offsets because the struct contains enum values that were themselves generated with the wrong sizes. Hopefully that's a problem we won't run into very often again, but it's one that's worth watching out for in the future.