### PR TITLE
Improve filter callback API redux

### DIFF
--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -5,8 +5,6 @@
 use ctru::applets::swkbd::{Button, CallbackResult, SoftwareKeyboard};
 use ctru::prelude::*;
 
-use std::ffi::CString;
-
 fn main() {
     let apt = Apt::new().unwrap();
     let mut hid = Hid::new().unwrap();
@@ -22,11 +20,10 @@ fn main() {
     // Using this callback it's possible to integrate the applet
     // with custom error messages when the input is incorrect.
     keyboard.set_filter_callback(Some(Box::new(|str| {
-        // The string is guaranteed to contain valid Unicode text, so we can safely unwrap and use it as a normal `&str`.
-        if str.to_str().unwrap().contains("boo") {
+        if str.contains("boo") {
             return (
                 CallbackResult::Retry,
-                Some(CString::new("Ah, you scared me!").unwrap()),
+                Some(String::from("Ah, you scared me!")),
             );
         }
 

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -19,7 +19,7 @@ fn main() {
     // Custom filter callback to handle the given input.
     // Using this callback it's possible to integrate the applet
     // with custom error messages when the input is incorrect.
-    keyboard.set_filter_callback(Some(Box::new(|str| {
+    keyboard.set_filter_callback(Some(Box::new(move |str| {
         if str.contains("boo") {
             return (CallbackResult::Retry, Some("Ah, you scared me!".into()));
         }

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -21,10 +21,7 @@ fn main() {
     // with custom error messages when the input is incorrect.
     keyboard.set_filter_callback(Some(Box::new(|str| {
         if str.contains("boo") {
-            return (
-                CallbackResult::Retry,
-                Some(String::from("Ah, you scared me!")),
-            );
+            return (CallbackResult::Retry, Some("Ah, you scared me!".into()));
         }
 
         (CallbackResult::Ok, None)

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -727,8 +727,10 @@ impl SoftwareKeyboard {
                 swkbd_shared_mem_ptr,
             };
 
-            if let Some(callback) = self.callback.as_ref() {
-                callback_data.callback = std::ptr::addr_of!(*callback);
+            // We need to pass a thin pointer to the boxed closure over FFI. Since we know that the callback will finish before
+            // `self` is allowed to be moved again, we can safely use a pointer to the local value contained in `self.callback`
+            if let Some(ref_to_boxed_closure) = self.callback.as_ref() {
+                callback_data.callback = ref_to_boxed_closure as *const _;
 
                 aptSetMessageCallback(
                     Some(Self::swkbd_message_callback),

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -830,8 +830,8 @@ impl SoftwareKeyboard {
         if let Some(msg) = retmsg.as_deref() {
             for (idx, code_unit) in msg
                 .encode_utf16()
-                .chain(once(0))
                 .take(swkbd.callback_msg.len() - 1)
+                .chain(once(0))
                 .enumerate()
             {
                 swkbd.callback_msg[idx] = code_unit;

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -12,12 +12,13 @@ use ctru_sys::{
 
 use bitflags::bitflags;
 
+use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::fmt::Display;
 use std::iter::once;
 use std::str;
 
-type CallbackFunction = dyn Fn(&str) -> (CallbackResult, Option<String>);
+type CallbackFunction = dyn Fn(&str) -> (CallbackResult, Option<Cow<str>>);
 
 /// Configuration structure to setup the Software Keyboard applet.
 #[doc(alias = "SwkbdState")]
@@ -342,17 +343,13 @@ impl SoftwareKeyboard {
     /// # fn main() {
     /// #
     /// use std::borrow::Cow;
-    /// use std::ffi::CString;
     /// use ctru::applets::swkbd::{SoftwareKeyboard, CallbackResult};
     ///
     /// let mut keyboard = SoftwareKeyboard::default();
     ///
     /// keyboard.set_filter_callback(Some(Box::new(|str| {
     ///     if str.contains("boo") {
-    ///         return (
-    ///             CallbackResult::Retry,
-    ///             Some(String::from("Ah, you scared me!")),
-    ///         );
+    ///         return (CallbackResult::Retry, Some("Ah, you scared me!".into()));
     ///     }
     ///
     ///     (CallbackResult::Ok, None)

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -348,7 +348,7 @@ impl SoftwareKeyboard {
     ///
     /// let mut keyboard = SoftwareKeyboard::default();
     ///
-    /// keyboard.set_filter_callback(Some(Box::new(|str| {
+    /// keyboard.set_filter_callback(Some(Box::new(move |str| {
     ///     if str.contains("boo") {
     ///         return (CallbackResult::Retry, Some("Ah, you scared me!".into()));
     ///     }

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -211,6 +211,7 @@ bitflags! {
 }
 
 // Internal book-keeping struct used to send data to `aptSetMessageCallback` when calling the software keyboard.
+#[derive(Copy, Clone)]
 struct MessageCallbackData {
     filter_callback: *const Box<CallbackFunction>,
     swkbd_shared_mem_ptr: *mut libc::c_void,
@@ -802,14 +803,14 @@ impl SoftwareKeyboard {
         msg: *mut libc::c_void,
         msg_size: libc::size_t,
     ) {
-        let data = unsafe { &mut *user.cast::<MessageCallbackData>() };
-        let swkbd = unsafe { &mut *msg.cast::<SwkbdState>() };
-
         if sender != ctru_sys::APPID_SOFTWARE_KEYBOARD
             || msg_size != std::mem::size_of::<SwkbdState>()
         {
             return;
         }
+
+        let swkbd = unsafe { &mut *msg.cast::<SwkbdState>() };
+        let data = unsafe { *user.cast::<MessageCallbackData>() };
 
         let text16 = unsafe {
             widestring::Utf16Str::from_slice_unchecked(std::slice::from_raw_parts(


### PR DESCRIPTION
Now that our code is in control of calling the software keyboard, we can switch away from using `CString`s in the filter callback without incurring extra allocations. Plus there's a lot of room to simplify the implementation overall, which I've been able to do here too.