### PR TITLE
Require unsafe blocks in unsafe fns

### DIFF
--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -847,7 +847,6 @@ impl SoftwareKeyboard {
 
     // A reimplementation of `swkbdMessageCallback` from `libctru/source/applets/swkbd.c`.
     // This function sets up and then calls the callback set by `swkbdSetFilterCallback`
-    #[deny(unsafe_op_in_unsafe_fn)]
     unsafe extern "C" fn swkbd_message_callback(
         user: *mut libc::c_void,
         sender: NS_APPID,

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -6,7 +6,6 @@
 //! Have a look at [`Soc::redirect_to_3dslink()`](crate::services::soc::Soc::redirect_to_3dslink) for a better alternative when debugging applications.
 
 use std::cell::{RefMut, UnsafeCell};
-use std::default::Default;
 
 use ctru_sys::{consoleClear, consoleInit, consoleSelect, consoleSetWindow, PrintConsole};
 

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -18,6 +18,7 @@
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
 #![warn(missing_docs)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![feature(custom_test_frameworks)]
 #![feature(try_trait_v2)]
 #![feature(allocator_api)]

--- a/ctru-rs/src/linear.rs
+++ b/ctru-rs/src/linear.rs
@@ -42,6 +42,8 @@ unsafe impl Allocator for LinearAllocator {
 
     #[doc(alias = "linearFree")]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
-        ctru_sys::linearFree(ptr.as_ptr().cast());
+        unsafe {
+            ctru_sys::linearFree(ptr.as_ptr().cast());
+        }
     }
 }

--- a/ctru-rs/src/services/ir_user.rs
+++ b/ctru-rs/src/services/ir_user.rs
@@ -347,9 +347,11 @@ impl IrUser {
         let mut shared_mem_guard = IR_USER_STATE.lock().unwrap();
         let shared_mem = shared_mem_guard.as_mut().unwrap();
 
-        shared_mem
-            .service_handle
-            .send_service_request(request, expected_response_len)
+        unsafe {
+            shared_mem
+                .service_handle
+                .send_service_request(request, expected_response_len)
+        }
     }
 }
 

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -21,7 +21,6 @@ use crate::error::ResultCode;
 use crate::services::ServiceReference;
 
 use std::cell::{RefCell, RefMut};
-use std::default::Default;
 use std::error;
 use std::fmt;
 use std::sync::Mutex;


### PR DESCRIPTION
Applies `#![deny(unsafe_op_in_unsafe_fn)]` to the whole crate, because marking unsafe code is a good idea even in unsafe functions.