### PR TITLE
Make ndsp::wave::Wave Send + Sync

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -26,6 +26,7 @@ libc = "0.2.121"
 bitflags = "2.3.3"
 macaddr = "1.0.1"
 widestring = "1.0.2"
+static_assertions = "1.1.0"
 
 [build-dependencies]
 toml = "0.5"

--- a/ctru-rs/src/services/ndsp/wave.rs
+++ b/ctru-rs/src/services/ndsp/wave.rs
@@ -2,6 +2,8 @@
 //!
 //! This modules has all methods and structs required to work with audio waves meant to be played via the [`ndsp`](crate::services::ndsp) service.
 
+use static_assertions::assert_impl_all;
+
 use super::{AudioFormat, Error};
 use crate::linear::LinearAllocator;
 
@@ -222,3 +224,13 @@ impl Drop for Wave {
         }
     }
 }
+
+// Safety: The 2 members we have to watch for are `adpcm_data` and `next`
+// we access neither of them directly in the wave API (at least currently) but
+// `next` at least _is_ used by the ndsp service internally. Given we do not
+// touch `next` ourselves and never should this is not an issue, and as long as
+// `adpcm_data` is not touched it should also be fine
+unsafe impl Send for Wave {}
+unsafe impl Sync for Wave {}
+
+assert_impl_all!(Wave: Send, Sync);


### PR DESCRIPTION
Currently the `Wave` wrapper struct is not `Send + Sync`, this is an issue for actually using it as data really needs to be fed to the ndsp service using threads or else it will cause audio clipping (libctru example uses threads and my own experience with a cpal backend supports this).

I need this to properly implement a cpal backend without resorting to [a wrapper](https://github.com/Team-Yarg/cpal/blob/9650bcaba8646d66fcf97ebc0665df9e89443612/src/host/ctru3ds/mod.rs#L129). 

In terms of soundness, as far as I can tell from reading the code and having the cpal backend seem to work fine, this should be okay. The libctru example also backs this up since it uses it in a multithreaded manner but I don't wanna rely on that being 100% correct :p.


Note I've added a dependency on `static_assertions` so that this part of the API is tested but I'm not married to it if its an issue