### PR TITLE
Generate smaller enum types

### DIFF
--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -15,7 +15,7 @@ pub struct PopUp {
 /// Determines whether the Error applet will use word wrapping when displaying a message.
 #[doc(alias = "errorType")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u16)]
 pub enum WordWrap {
     /// Error text is centered in the error applet window and does not use word wrapping.
     Disabled = ctru_sys::ERROR_TEXT,

--- a/ctru-rs/src/applets/mii_selector.rs
+++ b/ctru-rs/src/applets/mii_selector.rs
@@ -43,7 +43,7 @@ bitflags! {
     ///
     /// See [`MiiSelector::set_options()`] to learn how to use them.
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
-    pub struct Options: u32 {
+    pub struct Options: u8 {
         /// Show the cancel button.
         const ENABLE_CANCEL = ctru_sys::MIISELECTOR_CANCEL;
         /// Make guest Miis available to select.
@@ -135,7 +135,7 @@ impl MiiSelector {
     /// ```
     #[doc(alias = "miiSelectorSetOptions")]
     pub fn set_options(&mut self, options: Options) {
-        unsafe { ctru_sys::miiSelectorSetOptions(self.config.as_mut(), options.bits()) }
+        unsafe { ctru_sys::miiSelectorSetOptions(self.config.as_mut(), options.bits().into()) }
     }
 
     /// Allowlist a guest Mii based on its index.

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -50,8 +50,7 @@ impl Try for ResultCode {
         // Wait timeouts aren't counted as "failures" in libctru, but an unfinished task means unsafety for us.
         // Luckily all summary cases are for system failures (except RS_SUCCESS).
         // I don't know if there are any cases in libctru where a Result holds a "failing" summary but a "success" code, so we'll just check for both.
-        if ctru_sys::R_FAILED(self.0) || ctru_sys::R_SUMMARY(self.0) != ctru_sys::RS_SUCCESS as i32
-        {
+        if ctru_sys::R_FAILED(self.0) || ctru_sys::R_SUMMARY(self.0) != ctru_sys::RS_SUCCESS {
             ControlFlow::Break(self.into())
         } else {
             ControlFlow::Continue(())
@@ -119,7 +118,7 @@ impl Error {
     /// Check if the error is a timeout.
     pub fn is_timeout(&self) -> bool {
         match *self {
-            Error::Os(code) => R_DESCRIPTION(code) == ctru_sys::RD_TIMEOUT as ctru_sys::Result,
+            Error::Os(code) => R_DESCRIPTION(code) == ctru_sys::RD_TIMEOUT,
             _ => false,
         }
     }
@@ -193,7 +192,7 @@ fn result_code_level_str(result: ctru_sys::Result) -> Cow<'static, str> {
         RL_TEMPORARY, RL_USAGE,
     };
 
-    Cow::Borrowed(match R_LEVEL(result) as u32 {
+    Cow::Borrowed(match R_LEVEL(result) {
         RL_SUCCESS => "success",
         RL_INFO => "info",
         RL_FATAL => "fatal",
@@ -214,7 +213,7 @@ fn result_code_summary_str(result: ctru_sys::Result) -> Cow<'static, str> {
         RS_WOULDBLOCK, RS_WRONGARG,
     };
 
-    Cow::Borrowed(match R_SUMMARY(result) as u32 {
+    Cow::Borrowed(match R_SUMMARY(result) {
         RS_SUCCESS => "success",
         RS_NOP => "nop",
         RS_WOULDBLOCK => "would_block",
@@ -242,7 +241,7 @@ fn result_code_description_str(result: ctru_sys::Result) -> Cow<'static, str> {
         RD_SUCCESS, RD_TIMEOUT, RD_TOO_LARGE,
     };
 
-    Cow::Borrowed(match R_DESCRIPTION(result) as u32 {
+    Cow::Borrowed(match R_DESCRIPTION(result) {
         RD_SUCCESS => "success",
         RD_INVALID_RESULT_VALUE => "invalid_result_value",
         RD_TIMEOUT => "timeout",
@@ -292,7 +291,7 @@ fn result_code_module_str(result: ctru_sys::Result) -> Cow<'static, str> {
         RM_TCB, RM_TEST, RM_UART, RM_UDS, RM_UPDATER, RM_UTIL, RM_VCTL, RM_WEB_BROWSER,
     };
 
-    Cow::Borrowed(match R_MODULE(result) as u32 {
+    Cow::Borrowed(match R_MODULE(result) {
         RM_COMMON => "common",
         RM_KERNEL => "kernel",
         RM_UTIL => "util",

--- a/ctru-rs/src/os.rs
+++ b/ctru-rs/src/os.rs
@@ -70,7 +70,7 @@ pub fn kernel_version() -> Version {
 /// ```
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u32)]
+#[repr(u8)]
 pub enum MemRegion {
     /// All memory regions.
     All = ctru_sys::MEMREGION_ALL,
@@ -85,21 +85,21 @@ pub enum MemRegion {
 impl MemRegion {
     /// Get the total size of this memory region, in bytes.
     pub fn size(&self) -> usize {
-        unsafe { ctru_sys::osGetMemRegionSize(*self as u32) }
+        unsafe { ctru_sys::osGetMemRegionSize(*self as u8) }
             .try_into()
             .unwrap()
     }
 
     /// Get the number of bytes used within this memory region.
     pub fn used(&self) -> usize {
-        unsafe { ctru_sys::osGetMemRegionUsed(*self as u32) }
+        unsafe { ctru_sys::osGetMemRegionUsed(*self as u8) }
             .try_into()
             .unwrap()
     }
 
     /// Get the number of bytes free within this memory region.
     pub fn free(&self) -> usize {
-        unsafe { ctru_sys::osGetMemRegionFree(*self as u32) }
+        unsafe { ctru_sys::osGetMemRegionFree(*self as u8) }
             .try_into()
             .unwrap()
     }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -148,7 +148,9 @@ impl<'a> Chainloader<'a> {
     #[doc(alias = "aptIsChainload")]
     pub fn is_set(&self) -> bool {
         // static funtion not exported
-        unsafe { (ctru_sys::envGetSystemRunFlags() & ctru_sys::RUNFLAG_APTCHAINLOAD) != 0 }
+        unsafe {
+            (ctru_sys::envGetSystemRunFlags() & u32::from(ctru_sys::RUNFLAG_APTCHAINLOAD)) != 0
+        }
     }
 
     /// Clears the chainloader state.

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -33,7 +33,7 @@ pub struct Cam {
 /// See [`Camera::flip_image()`] to learn how to use this.
 #[doc(alias = "CAMU_Flip")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum FlipMode {
     /// No flip.
     None = ctru_sys::FLIP_NONE,
@@ -50,7 +50,7 @@ pub enum FlipMode {
 /// See [`Camera::set_view_size()`] to learn how to use this.
 #[doc(alias = "CAMU_Size")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum ViewSize {
     /// Size of the 3DS' top screen. (400 × 240)
     ///
@@ -79,7 +79,7 @@ pub enum ViewSize {
 /// See [`Camera::set_frame_rate()`] to learn how to use this.
 #[doc(alias = "CAMU_FramRate")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum FrameRate {
     /// 15 FPS.
     Fps15 = ctru_sys::FRAME_RATE_15,
@@ -114,7 +114,7 @@ pub enum FrameRate {
 /// See [`Camera::set_white_balance()`] to learn how to use this.
 #[doc(alias = "CAMU_WhiteBalance")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum WhiteBalance {
     /// Automatic white balance.
     Auto = ctru_sys::WHITE_BALANCE_AUTO,
@@ -135,7 +135,7 @@ pub enum WhiteBalance {
 /// See [`Camera::set_photo_mode()`] to learn how to use this.
 #[doc(alias = "CAMU_PhotoMode")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum PhotoMode {
     /// Normal mode.
     Normal = ctru_sys::PHOTO_MODE_NORMAL,
@@ -154,7 +154,7 @@ pub enum PhotoMode {
 /// See [`Camera::set_effect()`] to learn how to use this.
 #[doc(alias = "CAMU_Effect")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Effect {
     /// No effects.
     None = ctru_sys::EFFECT_NONE,
@@ -177,7 +177,7 @@ pub enum Effect {
 /// See [`Camera::set_contrast()`] to learn how to use this.
 #[doc(alias = "CAMU_Contrast")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Contrast {
     /// Low contrast.
     Low = ctru_sys::CONTRAST_LOW,
@@ -192,7 +192,7 @@ pub enum Contrast {
 /// See [`Camera::set_lens_correction()`] to learn how to use this.
 #[doc(alias = "CAMU_LensCorrection")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum LensCorrection {
     /// No lens correction.
     Off = ctru_sys::LENS_CORRECTION_DARK,
@@ -207,7 +207,7 @@ pub enum LensCorrection {
 /// See [`Camera::set_output_format()`] to learn how to use this.
 #[doc(alias = "CAMU_OutputFormat")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum OutputFormat {
     /// YUV422 output format. 16 bits per pixel.
     Yuv422 = ctru_sys::OUTPUT_YUV_422,
@@ -220,7 +220,7 @@ pub enum OutputFormat {
 /// See [`Cam::play_shutter_sound()`] to learn how to use this.
 #[doc(alias = "CAMU_ShutterSoundType")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum ShutterSound {
     /// Photo shutter sound.
     Normal = ctru_sys::SHUTTER_SOUND_TYPE_NORMAL,
@@ -406,29 +406,29 @@ impl BothOutwardCam {
 
 impl Camera for InwardCam {
     fn camera_as_raw(&self) -> ctru_sys::u32_ {
-        ctru_sys::SELECT_IN1
+        ctru_sys::SELECT_IN1.into()
     }
 }
 
 impl Camera for OutwardRightCam {
     fn camera_as_raw(&self) -> ctru_sys::u32_ {
-        ctru_sys::SELECT_OUT1
+        ctru_sys::SELECT_OUT1.into()
     }
 }
 
 impl Camera for OutwardLeftCam {
     fn camera_as_raw(&self) -> ctru_sys::u32_ {
-        ctru_sys::SELECT_OUT2
+        ctru_sys::SELECT_OUT2.into()
     }
 }
 
 impl Camera for BothOutwardCam {
     fn camera_as_raw(&self) -> ctru_sys::u32_ {
-        ctru_sys::SELECT_OUT1_OUT2
+        ctru_sys::SELECT_OUT1_OUT2.into()
     }
 
     fn port_as_raw(&self) -> ctru_sys::u32_ {
-        ctru_sys::PORT_BOTH
+        ctru_sys::PORT_BOTH.into()
     }
 
     fn take_picture(&mut self, buffer: &mut [u8], timeout: Duration) -> crate::Result<()> {
@@ -473,8 +473,8 @@ impl Camera for BothOutwardCam {
         // Synchronize the two cameras.
         unsafe {
             ResultCode(ctru_sys::CAMU_SynchronizeVsyncTiming(
-                ctru_sys::SELECT_OUT1,
-                ctru_sys::SELECT_OUT2,
+                ctru_sys::SELECT_OUT1.into(),
+                ctru_sys::SELECT_OUT2.into(),
             ))?;
         }
 
@@ -489,7 +489,7 @@ impl Camera for BothOutwardCam {
             ResultCode(ctru_sys::CAMU_SetReceiving(
                 &mut completion_handle,
                 buffer.as_mut_ptr().cast(),
-                ctru_sys::PORT_CAM1,
+                ctru_sys::PORT_CAM1.into(),
                 (max_size / 2) as u32,
                 transfer_unit.try_into().unwrap(),
             ))?;
@@ -503,7 +503,7 @@ impl Camera for BothOutwardCam {
             ResultCode(ctru_sys::CAMU_SetReceiving(
                 &mut completion_handle,
                 buffer[max_size / 2..].as_mut_ptr().cast(),
-                ctru_sys::PORT_CAM2,
+                ctru_sys::PORT_CAM2.into(),
                 (max_size / 2) as u32,
                 transfer_unit.try_into().unwrap(),
             ))?;
@@ -530,7 +530,7 @@ impl Camera for BothOutwardCam {
             // Camera state cleanup
             ResultCode(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
             ResultCode(ctru_sys::CAMU_ClearBuffer(self.port_as_raw()))?;
-            ResultCode(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
+            ResultCode(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE.into()))?;
 
             wait_result_1?;
             wait_result_2?;
@@ -558,7 +558,7 @@ pub trait Camera: private::ConfigurableCamera {
 
     /// Returns the raw port of the selected camera.
     fn port_as_raw(&self) -> ctru_sys::u32_ {
-        ctru_sys::PORT_CAM1
+        ctru_sys::PORT_CAM1.into()
     }
 
     /// Returns `true` if the camera is busy (receiving data).
@@ -621,7 +621,7 @@ pub trait Camera: private::ConfigurableCamera {
         let mut res: usize = (size.0 as usize * size.1 as usize) * std::mem::size_of::<i16>();
 
         // If we are taking a picture using both outwards cameras, we need to expect 2 images, rather than just 1
-        if self.port_as_raw() == ctru_sys::PORT_BOTH {
+        if self.port_as_raw() == ctru_sys::PORT_BOTH.into() {
             res *= 2;
         }
 
@@ -1088,7 +1088,7 @@ pub trait Camera: private::ConfigurableCamera {
             // Camera state cleanup
             ResultCode(ctru_sys::CAMU_StopCapture(self.port_as_raw()))?;
             ResultCode(ctru_sys::CAMU_ClearBuffer(self.port_as_raw()))?;
-            ResultCode(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE))?;
+            ResultCode(ctru_sys::CAMU_Activate(ctru_sys::SELECT_NONE.into()))?;
 
             wait_result?;
         };

--- a/ctru-rs/src/services/cfgu.rs
+++ b/ctru-rs/src/services/cfgu.rs
@@ -8,7 +8,7 @@ use crate::error::ResultCode;
 /// Console region.
 #[doc(alias = "CFG_Region")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Region {
     /// Japan.
     Japan = ctru_sys::CFG_REGION_JPN,
@@ -29,7 +29,7 @@ pub enum Region {
 /// Language set for the console's OS.
 #[doc(alias = "CFG_Language")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Language {
     /// Japanese.
     Japanese = ctru_sys::CFG_LANGUAGE_JP,
@@ -60,7 +60,7 @@ pub enum Language {
 /// Specific model of the console.
 #[doc(alias = "CFG_SystemModel")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum SystemModel {
     /// Old Nintendo 3DS.
     Old3DS = ctru_sys::CFG_MODEL_3DS,
@@ -251,7 +251,7 @@ impl TryFrom<u8> for Region {
     type Error = ();
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value as u32 {
+        match value {
             ctru_sys::CFG_REGION_JPN => Ok(Region::Japan),
             ctru_sys::CFG_REGION_USA => Ok(Region::USA),
             ctru_sys::CFG_REGION_EUR => Ok(Region::Europe),
@@ -268,7 +268,7 @@ impl TryFrom<u8> for Language {
     type Error = ();
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value as u32 {
+        match value {
             ctru_sys::CFG_LANGUAGE_JP => Ok(Language::Japanese),
             ctru_sys::CFG_LANGUAGE_EN => Ok(Language::English),
             ctru_sys::CFG_LANGUAGE_FR => Ok(Language::French),
@@ -290,7 +290,7 @@ impl TryFrom<u8> for SystemModel {
     type Error = ();
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value as u32 {
+        match value {
             ctru_sys::CFG_MODEL_3DS => Ok(SystemModel::Old3DS),
             ctru_sys::CFG_MODEL_3DSXL => Ok(SystemModel::Old3DSXL),
             ctru_sys::CFG_MODEL_N3DS => Ok(SystemModel::New3DS),

--- a/ctru-rs/src/services/fs.rs
+++ b/ctru-rs/src/services/fs.rs
@@ -7,14 +7,14 @@ use bitflags::bitflags;
 
 bitflags! {
     #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
-    struct Open: u32 {
+    struct Open: u8 {
         const FS_OPEN_READ   = ctru_sys::FS_OPEN_READ;
         const FS_OPEN_WRITE  = ctru_sys::FS_OPEN_WRITE;
         const FS_OPEN_CREATE = ctru_sys::FS_OPEN_CREATE;
     }
 
     #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
-    struct Write: u32 {
+    struct Write: u16 {
         const FS_WRITE_FLUSH       = ctru_sys::FS_WRITE_FLUSH;
         const FS_WRITE_UPDATE_TIME = ctru_sys::FS_WRITE_UPDATE_TIME;
     }
@@ -31,7 +31,7 @@ bitflags! {
 /// Media type used for storage.
 #[doc(alias = "FS_MediaType")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum MediaType {
     /// Internal NAND memory.
     Nand = ctru_sys::MEDIATYPE_NAND,
@@ -44,7 +44,7 @@ pub enum MediaType {
 /// Kind of file path.
 #[doc(alias = "FS_PathType")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum PathType {
     /// Invalid path.
     Invalid = ctru_sys::PATH_INVALID,

--- a/ctru-rs/src/services/gfx.rs
+++ b/ctru-rs/src/services/gfx.rs
@@ -219,7 +219,7 @@ pub struct RawFrameBuffer<'screen> {
 /// The top screen of the 3DS can have two separate sets of framebuffers to support its 3D functionality
 #[doc(alias = "gfx3dSide_t")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Side {
     /// The left framebuffer. This framebuffer is also the one used when 3D is disabled
     Left = ctru_sys::GFX_LEFT,

--- a/ctru-rs/src/services/gspgpu.rs
+++ b/ctru-rs/src/services/gspgpu.rs
@@ -3,7 +3,7 @@
 /// GSPGPU events that can be awaited.
 #[doc(alias = "GSPGPU_Event")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Event {
     /// Memory fill 1 completed.
     Psc0 = ctru_sys::GSPGPU_EVENT_PSC0,
@@ -24,7 +24,7 @@ pub enum Event {
 #[doc(alias = "GSPGPU_FramebufferFormat")]
 /// Framebuffer formats supported by the 3DS' screens.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum FramebufferFormat {
     /// RGBA8. 4 bytes per pixel
     Rgba8 = ctru_sys::GSP_RGBA8_OES,

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -30,7 +30,7 @@ const NUMBER_OF_CHANNELS: u8 = 24;
 /// Audio output mode.
 #[doc(alias = "ndspOutputMode")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum OutputMode {
     /// Single-Channel.
     Mono = ctru_sys::NDSP_OUTPUT_MONO,
@@ -42,7 +42,7 @@ pub enum OutputMode {
 
 /// PCM formats supported by the audio engine.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum AudioFormat {
     /// PCM 8bit single-channel.
     PCM8Mono = ctru_sys::NDSP_FORMAT_MONO_PCM8,
@@ -73,7 +73,7 @@ pub enum AuxDevice {
 /// Interpolation used between audio frames.
 #[doc(alias = "ndspInterpType")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum InterpolationType {
     /// Polyphase interpolation.
     Polyphase = ctru_sys::NDSP_INTERP_POLYPHASE,

--- a/ctru-rs/src/services/ndsp/wave.rs
+++ b/ctru-rs/src/services/ndsp/wave.rs
@@ -22,13 +22,13 @@ pub struct Wave {
 /// Playback status of a [`Wave`].
 pub enum Status {
     /// Wave has never been used.
-    Free = ctru_sys::NDSP_WBUF_FREE as u8,
+    Free = ctru_sys::NDSP_WBUF_FREE,
     /// Wave is currently queued for usage.
-    Queued = ctru_sys::NDSP_WBUF_QUEUED as u8,
+    Queued = ctru_sys::NDSP_WBUF_QUEUED,
     /// Wave is currently playing.
-    Playing = ctru_sys::NDSP_WBUF_PLAYING as u8,
+    Playing = ctru_sys::NDSP_WBUF_PLAYING,
     /// Wave has finished playing.
-    Done = ctru_sys::NDSP_WBUF_DONE as u8,
+    Done = ctru_sys::NDSP_WBUF_DONE,
 }
 
 impl Wave {

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -12,7 +12,7 @@ use crate::Result;
 /// Type of AES algorithm to use.
 #[doc(alias = "PS_AESAlgorithm")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum AESAlgorithm {
     /// CBC encryption.
     CbcEnc = ctru_sys::PS_ALGORITHM_CBC_ENC,
@@ -31,7 +31,7 @@ pub enum AESAlgorithm {
 /// PS Key slot to use.
 #[doc(alias = "PS_AESKeyType")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum AESKeyType {
     /// Keyslot 0x0D.
     Keyslot0D = ctru_sys::PS_KEYSLOT_0D,

--- a/ctru-rs/src/services/romfs.rs
+++ b/ctru-rs/src/services/romfs.rs
@@ -90,7 +90,7 @@ mod tests {
     fn romfs_lock() {
         let romfs = RomFS::new().unwrap();
 
-        ROMFS_ACTIVE.try_lock().unwrap();
+        drop(ROMFS_ACTIVE.try_lock().unwrap());
 
         drop(romfs);
     }

--- a/ctru-rs/src/services/uds.rs
+++ b/ctru-rs/src/services/uds.rs
@@ -99,7 +99,7 @@ impl StdError for Error {}
 /// Possible types of connection to a network.
 #[doc(alias = "udsConnectionType")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum ConnectionType {
     /// A normal client. Can push packets to the network.
     Client = ctru_sys::UDSCONTYPE_Client,
@@ -118,7 +118,7 @@ impl TryFrom<u8> for ConnectionType {
     type Error = ();
 
     fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
-        match value as u32 {
+        match value {
             ctru_sys::UDSCONTYPE_Client => Ok(Self::Client),
             ctru_sys::UDSCONTYPE_Spectator => Ok(Self::Spectator),
             _ => Err(()),
@@ -696,7 +696,7 @@ impl Uds {
                 passphrase.len(),
                 context.as_mut_ptr(),
                 NodeID::Broadcast.into(),
-                connection_type as u32,
+                connection_type as u8,
                 channel,
                 Self::RECV_BUF_SIZE,
             )

--- a/ctru-rs/src/services/uds.rs
+++ b/ctru-rs/src/services/uds.rs
@@ -24,9 +24,9 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct SendFlags: u8 {
         /// Unknown function according to `libctru`.
-        const Default = ctru_sys::UDS_SENDFLAG_Default as u8;
+        const Default = ctru_sys::UDS_SENDFLAG_Default;
         /// Broadcast the data frame even when sending to a non-broadcast address.
-        const Broadcast = ctru_sys::UDS_SENDFLAG_Broadcast as u8;
+        const Broadcast = ctru_sys::UDS_SENDFLAG_Broadcast;
     }
 }
 

--- a/ctru-sys/build.rs
+++ b/ctru-sys/build.rs
@@ -79,8 +79,6 @@ fn main() {
         .blocklist_type("u(8|16|32|64)")
         .blocklist_type("__builtin_va_list")
         .blocklist_type("__va_list")
-        .blocklist_type("errorReturnCode")
-        .blocklist_type("errorScreenFlag")
         .opaque_type("MiiData")
         .derive_default(true)
         .wrap_static_fns(true)
@@ -101,6 +99,15 @@ fn main() {
             "-mfpu=vfp",
             "-DARM11",
             "-D__3DS__",
+            // Fun fact: C compilers are allowed to represent enums as the smallest
+            // integer type that can hold all of its variants, meaning that enums are
+            // allowed to be the size of a `c_short` or a `c_char` rather than the size
+            // of a `c_int`. Some of libctru's structs contain enums that depend on
+            // this narrowing property for size and alignment purposes.
+            //
+            // Passing this flag to clang gives approximately the same behavior as
+            // gcc, so bindgen will generate enums with the proper sizes.
+            "-fshort-enums",
         ])
         .parse_callbacks(Box::new(CustomCallbacks))
         .generate()

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -16,24 +16,6 @@
 pub mod result;
 pub use result::*;
 
-// Fun fact: C compilers are allowed to represent enums as the smallest integer type that can hold all of its variants,
-// meaning that enums are allowed to be the size of a `c_short` or a `c_char` rather than the size of a `c_int`.
-// Libctru's `errorConf` struct contains two enums that depend on this narrowing property for size and alignment purposes,
-// and since `bindgen` generates all enums with `c_int` sizing, we have to blocklist those types and manually define them
-// here with the proper size.
-pub type errorReturnCode = libc::c_schar;
-pub const ERROR_UNKNOWN: errorReturnCode = -1;
-pub const ERROR_NONE: errorReturnCode = 0;
-pub const ERROR_SUCCESS: errorReturnCode = 1;
-pub const ERROR_NOT_SUPPORTED: errorReturnCode = 2;
-pub const ERROR_HOME_BUTTON: errorReturnCode = 10;
-pub const ERROR_SOFTWARE_RESET: errorReturnCode = 11;
-pub const ERROR_POWER_BUTTON: errorReturnCode = 12;
-
-pub type errorScreenFlag = libc::c_char;
-pub const ERROR_NORMAL: errorScreenFlag = 0;
-pub const ERROR_STEREO: errorScreenFlag = 1;
-
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 /// In lieu of a proper errno function exposed by libc

--- a/ctru-sys/src/result.rs
+++ b/ctru-sys/src/result.rs
@@ -14,23 +14,23 @@ pub fn R_FAILED(res: Result) -> bool {
 }
 
 /// Returns the level of a result code.
-pub fn R_LEVEL(res: Result) -> Result {
-    (res >> 27) & 0x1F
+pub fn R_LEVEL(res: Result) -> libc::c_uchar {
+    ((res >> 27) & 0x1F) as _
 }
 
 /// Returns the summary of a result code.
-pub fn R_SUMMARY(res: Result) -> Result {
-    (res >> 21) & 0x3F
+pub fn R_SUMMARY(res: Result) -> libc::c_uchar {
+    ((res >> 21) & 0x3F) as _
 }
 
 /// Returns the module ID of a result code.
-pub fn R_MODULE(res: Result) -> Result {
-    (res >> 10) & 0xFF
+pub fn R_MODULE(res: Result) -> libc::c_uchar {
+    ((res >> 10) & 0xFF) as _
 }
 
 /// Returns the description of a result code.
-pub fn R_DESCRIPTION(res: Result) -> Result {
-    res & 0x3FF
+pub fn R_DESCRIPTION(res: Result) -> libc::c_ushort {
+    (res & 0x3FF) as _
 }
 
 /// Builds a result code from its constituent components.


### PR DESCRIPTION
Closes #166 I guess?

Related to https://github.com/rust3ds/ctru-rs/pull/178#pullrequestreview-2013120422 and some of the changes in #162 


By passing -fshort-enums to clang, we can get the same smaller types that gcc generates for some of these enums.

This also makes sure the layout tests have the same smaller sizes, so the expected sizes now match the actual sizes of the same C structs.

----

One thing this doesn't do is truly check that GCC is generating the same everything... ideally, I think we'd want to link against a C lib that had a bunch of APIs like this or something:
```c
size_t sizeof_errorType() { return sizeof(errorType); }
size_t alignof_errorType() { return alignof(errorType); }
size_t offsetof_errorType() { return offsetof(errorConf, type); }
```
and then a Rust test like
```rs
extern "C" {
	fn sizeof_errorType() -> libc::size_t;
	fn aligneof_errorType() -> libc::size_t;
	fn offsetof_errorType() -> libc::size_t;
}

#[test]
fn layouts() {
	assert_eq!(mem::size_of<errorType>(), sizeof_errorType());
	assert_eq!(mem::align_of<errorType>(), alignof_errorType());
	assert_eq!(mem::offset_of!(errorConf, type_), offsetof_errorType());
}
```

But without `bindgen` doing something like this for us, this seems like a tricky thing to write unless we just do it manually. So for now I think I'll kinda ignore that and leave it as a future enhancement if we really need it.