### PR TITLE
Add trait for linear allocation to enforce use of LinearAllocator at compile-time

### DIFF
--- a/ctru-rs/examples/audio-filters.rs
+++ b/ctru-rs/examples/audio-filters.rs
@@ -5,7 +5,6 @@
 #![feature(allocator_api)]
 
 use std::f32::consts::PI;
-use std::ops::Deref;
 
 use ctru::linear::LinearAllocator;
 use ctru::prelude::*;

--- a/ctru-rs/examples/audio-filters.rs
+++ b/ctru-rs/examples/audio-filters.rs
@@ -5,6 +5,7 @@
 #![feature(allocator_api)]
 
 use std::f32::consts::PI;
+use std::ops::Deref;
 
 use ctru::linear::LinearAllocator;
 use ctru::prelude::*;
@@ -64,10 +65,10 @@ fn main() {
 
     // We create a buffer on the LINEAR memory that will hold our audio data.
     // It's necessary for the buffer to live on the LINEAR memory sector since it needs to be accessed by the DSP processor.
-    let mut audio_data1 = Box::new_in([0u8; AUDIO_WAVE_LENGTH], LinearAllocator);
+    let mut audio_data1: Box<[_], _> = Box::new_in([0u8; AUDIO_WAVE_LENGTH], LinearAllocator);
 
     // Fill the buffer with the first set of data. This simply writes a sine wave into the buffer.
-    fill_buffer(audio_data1.as_mut_slice(), NOTEFREQ[4]);
+    fill_buffer(&mut audio_data1, NOTEFREQ[4]);
 
     // Clone the original buffer to obtain an equal buffer on the LINEAR memory used for double buffering.
     let audio_data2 = audio_data1.clone();
@@ -154,7 +155,7 @@ fn main() {
         }
 
         // Double buffer alternation depending on the one used.
-        let current: &mut Wave = if altern {
+        let current: &mut Wave<_> = if altern {
             &mut wave_info1
         } else {
             &mut wave_info2

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(try_trait_v2)]
 #![feature(allocator_api)]
 #![feature(new_uninit)]
+#![feature(diagnostic_namespace)]
 #![test_runner(test_runner::run_gdb)] // TODO: does this make sense to have configurable?
 #![doc(
     html_favicon_url = "https://user-images.githubusercontent.com/11131775/225929072-2fa1741c-93ae-4b47-9bdf-af70f3d59910.png"

--- a/ctru-rs/src/linear.rs
+++ b/ctru-rs/src/linear.rs
@@ -10,6 +10,10 @@
 
 use std::alloc::{AllocError, Allocator, Layout};
 use std::ptr::NonNull;
+use std::rc::{self, Rc};
+use std::sync::{self, Arc};
+
+use crate::sealed::Sealed;
 
 // Implementing an `std::alloc::Allocator` type is the best way to handle this case, since it gives
 // us full control over the normal `std` implementations (like `Box`). The only issue is that this is another unstable feature to add.
@@ -47,3 +51,32 @@ unsafe impl Allocator for LinearAllocator {
         }
     }
 }
+
+/// Trait indicating a type has been allocated using [`LinearAllocator`].
+/// This can be used to enforce that a given slice was allocated in LINEAR memory.
+#[diagnostic::on_unimplemented(
+    message = "{Self} is not allocated with `ctru::linear::LinearAllocator`"
+)]
+pub trait LinearAllocation: Sealed {}
+
+impl<T> Sealed for Vec<T, LinearAllocator> {}
+impl<T> LinearAllocation for Vec<T, LinearAllocator> {}
+
+impl<T: ?Sized> Sealed for Rc<T, LinearAllocator> {}
+impl<T: ?Sized> LinearAllocation for Rc<T, LinearAllocator> {}
+
+impl<T: ?Sized> Sealed for rc::Weak<T, LinearAllocator> {}
+impl<T: ?Sized> LinearAllocation for rc::Weak<T, LinearAllocator> {}
+
+impl<T: ?Sized> Sealed for Arc<T, LinearAllocator> {}
+impl<T: ?Sized> LinearAllocation for Arc<T, LinearAllocator> {}
+
+impl<T: ?Sized> Sealed for sync::Weak<T, LinearAllocator> {}
+impl<T: ?Sized> LinearAllocation for sync::Weak<T, LinearAllocator> {}
+
+impl<T: ?Sized> Sealed for Box<T, LinearAllocator> {}
+impl<T: ?Sized> LinearAllocation for Box<T, LinearAllocator> {}
+
+// We could also impl for various std::collections types, but it seems unlikely
+// those would ever be used for this purpose in practice, since most of the type
+// we're dereferencing to a &[T]. The workaround would just be to convert to a Vec.

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -24,7 +24,6 @@ use crate::services::ServiceReference;
 use std::cell::{RefCell, RefMut};
 use std::error;
 use std::fmt;
-use std::ops::Deref;
 use std::sync::Mutex;
 
 const NUMBER_OF_CHANNELS: u8 = 24;
@@ -539,7 +538,7 @@ impl Channel<'_> {
     // TODO: Find a better way to handle the wave lifetime problem.
     //       These "alive wave" shenanigans are the most substantial reason why I'd like to fully re-write this service in Rust.
     #[doc(alias = "ndspChnWaveBufAdd")]
-    pub fn queue_wave<Buffer: LinearAllocation + Deref<Target = [u8]>>(
+    pub fn queue_wave<Buffer: LinearAllocation + AsRef<[u8]>>(
         &mut self,
         wave: &mut Wave<Buffer>,
     ) -> std::result::Result<(), Error> {

--- a/ctru-rs/src/services/ndsp/wave.rs
+++ b/ctru-rs/src/services/ndsp/wave.rs
@@ -2,15 +2,13 @@
 //!
 //! This modules has all methods and structs required to work with audio waves meant to be played via the [`ndsp`](crate::services::ndsp) service.
 
-use std::ops::{Deref, DerefMut};
-
 use super::{AudioFormat, Error};
 use crate::linear::LinearAllocation;
 
 /// Informational struct holding the raw audio data and playback info.
 ///
 /// You can play audio [`Wave`]s by using [`Channel::queue_wave()`](super::Channel::queue_wave).
-pub struct Wave<Buffer: LinearAllocation + Deref<Target = [u8]>> {
+pub struct Wave<Buffer: LinearAllocation + AsRef<[u8]>> {
     /// Data block of the audio wave (and its format information).
     buffer: Buffer,
     audio_format: AudioFormat,
@@ -35,7 +33,7 @@ pub enum Status {
 
 impl<Buffer> Wave<Buffer>
 where
-    Buffer: LinearAllocation + Deref<Target = [u8]>,
+    Buffer: LinearAllocation + AsRef<[u8]>,
 {
     /// Build a new playable wave object from a raw buffer on [LINEAR memory](`crate::linear`) and some info.
     ///
@@ -56,16 +54,17 @@ where
     /// # }
     /// ```
     pub fn new(buffer: Buffer, audio_format: AudioFormat, looping: bool) -> Self {
-        let sample_count = buffer.len() / audio_format.size();
+        let buf = buffer.as_ref();
+        let sample_count = buf.len() / audio_format.size();
 
         // Signal to the DSP processor the buffer's RAM sector.
         // This step may seem delicate, but testing reports failure most of the time, while still having no repercussions on the resulting audio.
         unsafe {
-            let _r = ctru_sys::DSP_FlushDataCache(buffer.as_ptr().cast(), buffer.len() as u32);
+            let _r = ctru_sys::DSP_FlushDataCache(buf.as_ptr().cast(), buf.len() as u32);
         }
 
         let address = ctru_sys::tag_ndspWaveBuf__bindgen_ty_1 {
-            data_vaddr: buffer.as_ptr().cast(),
+            data_vaddr: buf.as_ptr().cast(),
         };
 
         let raw_data = ctru_sys::ndspWaveBuf {
@@ -90,7 +89,7 @@ where
 
     /// Returns a slice to the audio data (on the LINEAR memory).
     pub fn get_buffer(&self) -> &[u8] {
-        &self.buffer
+        self.buffer.as_ref()
     }
 
     /// Returns a mutable slice to the audio data (on the LINEAR memory).
@@ -101,13 +100,13 @@ where
     /// with the id to the channel in which it's queued.
     pub fn get_buffer_mut(&mut self) -> Result<&mut [u8], Error>
     where
-        Buffer: DerefMut<Target = [u8]>,
+        Buffer: AsMut<[u8]>,
     {
         match self.status() {
             Status::Playing | Status::Queued => {
                 Err(Error::WaveBusy(self.played_on_channel.unwrap()))
             }
-            _ => Ok(&mut self.buffer),
+            _ => Ok(self.buffer.as_mut()),
         }
     }
 
@@ -177,7 +176,7 @@ where
             _ => (),
         }
 
-        let max_count = self.buffer.len() / self.audio_format.size();
+        let max_count = self.buffer.as_ref().len() / self.audio_format.size();
 
         if sample_count > max_count {
             return Err(Error::SampleCountOutOfBounds(sample_count, max_count));
@@ -205,7 +204,7 @@ impl TryFrom<u8> for Status {
 
 impl<Buffer> Drop for Wave<Buffer>
 where
-    Buffer: LinearAllocation + Deref<Target = [u8]>,
+    Buffer: LinearAllocation + AsRef<[u8]>,
 {
     fn drop(&mut self) {
         // This was the only way I found I could check for improper drops of `Wave`.
@@ -223,8 +222,8 @@ where
             // Flag the buffer's RAM sector as unused
             // This step has no real effect in normal applications and is skipped even by devkitPRO's own examples.
             let _r = ctru_sys::DSP_InvalidateDataCache(
-                self.buffer.as_ptr().cast(),
-                self.buffer.len().try_into().unwrap(),
+                self.get_buffer().as_ptr().cast(),
+                self.get_buffer().len().try_into().unwrap(),
             );
         }
     }


### PR DESCRIPTION
Also convert `ndsp::Wave` to be generic over any linearly-allocated type so that callers could use Vec etc. if they wanted.

This will also be useful for `citro3d-rs`, e.g. https://github.com/rust3ds/citro3d-rs/pull/42/files#r1477434491


