### PR TITLE
Update ctru-rs to the 2024 edition.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           # Run against a "known good" nightly. Rustc version is 1 day behind the toolchain date
-          - nightly-2024-03-10
+          - nightly-2025-03-30
           # Check for breakage on latest nightly
           - nightly
 
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - nightly-2024-03-10
+          - nightly-2025-03-30
           - nightly
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     runs-on: ubuntu-latest

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["3ds", "libctru"]
 categories = ["os", "api-bindings", "hardware-support"]
 exclude = ["examples"]
 license = "Zlib"
-edition = "2021"
-rust-version = "1.78"
+edition = "2024"
+rust-version = "1.85"
 
 [lib]
 crate-type = ["rlib"]

--- a/ctru-rs/examples/audio-filters.rs
+++ b/ctru-rs/examples/audio-filters.rs
@@ -9,8 +9,8 @@ use std::f32::consts::PI;
 use ctru::linear::LinearAllocator;
 use ctru::prelude::*;
 use ctru::services::ndsp::{
-    wave::{Status, Wave},
     AudioFormat, AudioMix, InterpolationType, Ndsp, OutputMode,
+    wave::{Status, Wave},
 };
 
 // Configuration for the NDSP process and channels.

--- a/ctru-rs/examples/file-explorer.rs
+++ b/ctru-rs/examples/file-explorer.rs
@@ -104,7 +104,9 @@ impl<'a> FileExplorer<'a> {
             }
         };
 
-        println!("Press Start to exit, A to select an entry by number, B to go up a directory, X to set the path.");
+        println!(
+            "Press Start to exit, A to select an entry by number, B to go up a directory, X to set the path."
+        );
     }
 
     fn print_dir_entries(&mut self) {

--- a/ctru-rs/examples/ir-user-circle-pad-pro.rs
+++ b/ctru-rs/examples/ir-user-circle-pad-pro.rs
@@ -19,7 +19,7 @@ const CPP_POLLING_PERIOD_MS: u8 = 0x32;
 
 // This export tells libctru to not initialize ir:rst when initializing HID.
 // This is necessary on the New 3DS because ir:rst is mutually exclusive with ir:USER.
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn hidShouldUseIrrst() -> bool {
     false
 }

--- a/ctru-rs/examples/local-networking.rs
+++ b/ctru-rs/examples/local-networking.rs
@@ -120,7 +120,9 @@ fn main() -> Result<(), Error> {
                     if networks.len() == 1 { "" } else { "s" }
                 );
 
-                println!("D-Pad to select, A to connect as client, R + A to connect as spectator, B to create a new network");
+                println!(
+                    "D-Pad to select, A to connect as client, R + A to connect as spectator, B to create a new network"
+                );
 
                 for (index, n) in networks.iter().enumerate() {
                     println!(
@@ -238,7 +240,7 @@ fn main() -> Result<(), Error> {
                         let appdata = [0x69u8, 0x8a, 0x05, 0x5c]
                             .into_iter()
                             .chain((*b"Test appdata.").into_iter())
-                            .chain(std::iter::repeat(0).take(3))
+                            .chain(std::iter::repeat_n(0, 3))
                             .collect::<Vec<_>>();
 
                         uds.set_appdata(&appdata)?;

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -5,9 +5,9 @@
 
 use crate::services::{apt::Apt, gfx::Gfx};
 use ctru_sys::{
-    aptLaunchLibraryApplet, aptSetMessageCallback, envGetAptAppId, svcCloseHandle,
-    svcCreateMemoryBlock, APT_SendParameter, SwkbdButton, SwkbdDictWord, SwkbdLearningData,
-    SwkbdState, SwkbdStatusData, APPID_SOFTWARE_KEYBOARD, APTCMD_MESSAGE, NS_APPID,
+    APPID_SOFTWARE_KEYBOARD, APT_SendParameter, APTCMD_MESSAGE, NS_APPID, SwkbdButton,
+    SwkbdDictWord, SwkbdLearningData, SwkbdState, SwkbdStatusData, aptLaunchLibraryApplet,
+    aptSetMessageCallback, envGetAptAppId, svcCloseHandle, svcCreateMemoryBlock,
 };
 
 use bitflags::bitflags;
@@ -733,15 +733,12 @@ impl SoftwareKeyboard {
             // `self` is allowed to be moved again, we can safely use a pointer to the local value contained in `self.filter_callback`
             // The cast here is also sound since the pointer will only be read from if `self.filter_callback.is_some()` returns true.
             let mut data = MessageCallbackData {
-                filter_callback: std::ptr::addr_of!(self.filter_callback).cast(),
+                filter_callback: (&raw const self.filter_callback).cast(),
                 swkbd_shared_mem_ptr,
             };
 
             if self.filter_callback.is_some() {
-                aptSetMessageCallback(
-                    Some(Self::swkbd_message_callback),
-                    std::ptr::addr_of_mut!(data).cast(),
-                )
+                aptSetMessageCallback(Some(Self::swkbd_message_callback), (&raw mut data).cast())
             }
 
             aptLaunchLibraryApplet(

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -7,7 +7,7 @@
 
 use std::cell::{RefMut, UnsafeCell};
 
-use ctru_sys::{consoleClear, consoleInit, consoleSelect, consoleSetWindow, PrintConsole};
+use ctru_sys::{PrintConsole, consoleClear, consoleInit, consoleSelect, consoleSetWindow};
 
 use crate::services::gfx::{Flush, Screen, Swap};
 
@@ -142,7 +142,7 @@ impl<'screen> Console<'screen> {
     /// ```
     pub fn exists() -> bool {
         unsafe {
-            let current_console = ctru_sys::consoleSelect(std::ptr::addr_of_mut!(EMPTY_CONSOLE));
+            let current_console = ctru_sys::consoleSelect(&raw mut EMPTY_CONSOLE);
 
             let res = (*current_console).consoleInitialised;
 
@@ -366,7 +366,7 @@ impl Drop for Console<'_> {
             // the screen, but it won't crash either.
 
             // Get the current console by replacing it with an empty one.
-            let current_console = ctru_sys::consoleSelect(std::ptr::addr_of_mut!(EMPTY_CONSOLE));
+            let current_console = ctru_sys::consoleSelect(&raw mut EMPTY_CONSOLE);
 
             if std::ptr::eq(current_console, self.context.get()) {
                 // Console dropped while selected. We just replaced it with the

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -178,7 +178,10 @@ impl fmt::Display for Error {
             Self::OutputAlreadyRedirected => {
                 write!(f, "output streams are already redirected to 3dslink")
             }
-            Self::BufferTooShort{provided, wanted} => write!(f, "the provided buffer's length is too short (length = {provided}) to hold the wanted data (size = {wanted})"),
+            Self::BufferTooShort { provided, wanted } => write!(
+                f,
+                "the provided buffer's length is too short (length = {provided}) to hold the wanted data (size = {wanted})"
+            ),
             Self::Other(err) => write!(f, "{err}"),
         }
     }
@@ -236,9 +239,9 @@ fn result_code_description_str(result: ctru_sys::Result) -> Cow<'static, str> {
         RD_ALREADY_DONE, RD_ALREADY_EXISTS, RD_ALREADY_INITIALIZED, RD_BUSY, RD_CANCEL_REQUESTED,
         RD_INVALID_ADDRESS, RD_INVALID_COMBINATION, RD_INVALID_ENUM_VALUE, RD_INVALID_HANDLE,
         RD_INVALID_POINTER, RD_INVALID_RESULT_VALUE, RD_INVALID_SELECTION, RD_INVALID_SIZE,
-        RD_MISALIGNED_ADDRESS, RD_MISALIGNED_SIZE, RD_NOT_AUTHORIZED, RD_NOT_FOUND,
-        RD_NOT_IMPLEMENTED, RD_NOT_INITIALIZED, RD_NO_DATA, RD_OUT_OF_MEMORY, RD_OUT_OF_RANGE,
-        RD_SUCCESS, RD_TIMEOUT, RD_TOO_LARGE,
+        RD_MISALIGNED_ADDRESS, RD_MISALIGNED_SIZE, RD_NO_DATA, RD_NOT_AUTHORIZED, RD_NOT_FOUND,
+        RD_NOT_IMPLEMENTED, RD_NOT_INITIALIZED, RD_OUT_OF_MEMORY, RD_OUT_OF_RANGE, RD_SUCCESS,
+        RD_TIMEOUT, RD_TOO_LARGE,
     };
 
     Cow::Borrowed(match R_DESCRIPTION(result) {
@@ -280,7 +283,7 @@ fn result_code_description_str(result: ctru_sys::Result) -> Cow<'static, str> {
 fn result_code_module_str(result: ctru_sys::Result) -> Cow<'static, str> {
     use ctru_sys::{
         RM_AC, RM_ACC, RM_ACT, RM_AM, RM_AM_LOW, RM_APPLET, RM_APPLICATION, RM_AVD, RM_BOSS,
-        RM_CAM, RM_CARD, RM_CARDNOR, RM_CARD_SPI, RM_CEC, RM_CODEC, RM_COMMON, RM_CONFIG, RM_CSND,
+        RM_CAM, RM_CARD, RM_CARD_SPI, RM_CARDNOR, RM_CEC, RM_CODEC, RM_COMMON, RM_CONFIG, RM_CSND,
         RM_CUP, RM_DBG, RM_DBM, RM_DD, RM_DI, RM_DLP, RM_DMNT, RM_DSP, RM_EC, RM_ENC, RM_FATFS,
         RM_FILE_SERVER, RM_FND, RM_FRIENDS, RM_FS, RM_FSI, RM_GD, RM_GPIO, RM_GSP, RM_GYROSCOPE,
         RM_HID, RM_HIO, RM_HIO_LOW, RM_HTTP, RM_I2C, RM_INVALIDRESVAL, RM_IR, RM_KERNEL, RM_L2B,

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -22,7 +22,6 @@
 #![feature(custom_test_frameworks)]
 #![feature(try_trait_v2)]
 #![feature(allocator_api)]
-#![feature(new_uninit)]
 #![test_runner(test_runner::run_gdb)] // TODO: does this make sense to have configurable?
 #![doc(
     html_favicon_url = "https://user-images.githubusercontent.com/11131775/225929072-2fa1741c-93ae-4b47-9bdf-af70f3d59910.png"
@@ -41,7 +40,7 @@ extern crate shim_3ds;
 /// It takes effect only if the `big-stack` feature is active. Otherwise, the default stack size should be ~32kB.
 ///
 /// This value was chosen to support crate dependencies which expected more stack than provided. It's suggested to use less stack if possible.
-#[no_mangle]
+#[unsafe(no_mangle)]
 // When building lib tests, we don't want to redefine the same symbol twice,
 // since ctru-rs is both the crate under test and a dev-dependency (non-test).
 // We might also be able to use #[linkage] for similar effect, but this way

--- a/ctru-rs/src/services/cam.rs
+++ b/ctru-rs/src/services/cam.rs
@@ -5,8 +5,8 @@
 #![doc(alias = "camera")]
 
 use crate::error::{Error, ResultCode};
-use crate::services::gspgpu::FramebufferFormat;
 use crate::services::ServiceReference;
+use crate::services::gspgpu::FramebufferFormat;
 use ctru_sys::Handle;
 use private::Configuration;
 

--- a/ctru-rs/src/services/gfx.rs
+++ b/ctru-rs/src/services/gfx.rs
@@ -10,8 +10,8 @@ use std::sync::Mutex;
 
 use crate::error::Result;
 use crate::sealed::Sealed;
-use crate::services::gspgpu::{self, FramebufferFormat};
 use crate::services::ServiceReference;
+use crate::services::gspgpu::{self, FramebufferFormat};
 
 /// Trait to handle common functionality for all screens.
 ///

--- a/ctru-rs/src/services/ir_user.rs
+++ b/ctru-rs/src/services/ir_user.rs
@@ -10,10 +10,10 @@
 #![doc(alias = "controller")]
 #![doc(alias = "gamepad")]
 
-use crate::error::ResultCode;
-use crate::services::svc::{make_ipc_header, HandleExt};
-use crate::services::ServiceReference;
 use crate::Error;
+use crate::error::ResultCode;
+use crate::services::ServiceReference;
+use crate::services::svc::{HandleExt, make_ipc_header};
 use ctru_sys::{Handle, MEMPERM_READ, MEMPERM_READWRITE};
 use std::alloc::Layout;
 use std::ffi::CString;

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -766,10 +766,19 @@ impl From<[f32; 12]> for AudioMix {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::InvalidChannel(id) => write!(f, "audio Channel with ID {id} doesn't exist. Valid channels have an ID between 0 and 23"),
-            Self::ChannelAlreadyInUse(id) => write!(f, "audio Channel with ID {id} is already being used. Drop the other instance if you want to use it here"),
+            Self::InvalidChannel(id) => write!(
+                f,
+                "audio Channel with ID {id} doesn't exist. Valid channels have an ID between 0 and 23"
+            ),
+            Self::ChannelAlreadyInUse(id) => write!(
+                f,
+                "audio Channel with ID {id} is already being used. Drop the other instance if you want to use it here"
+            ),
             Self::WaveBusy(id) => write!(f, "the selected Wave is busy playing on channel {id}"),
-            Self::SampleCountOutOfBounds(samples_requested, max_samples) => write!(f, "the sample count requested is too big (requested = {samples_requested}, maximum = {max_samples})"),
+            Self::SampleCountOutOfBounds(samples_requested, max_samples) => write!(
+                f,
+                "the sample count requested is too big (requested = {samples_requested}, maximum = {max_samples})"
+            ),
         }
     }
 }

--- a/ctru-rs/src/services/ps.rs
+++ b/ctru-rs/src/services/ps.rs
@@ -6,8 +6,8 @@
 //!
 //! See also <https://www.3dbrew.org/wiki/Process_Services>
 
-use crate::error::ResultCode;
 use crate::Result;
+use crate::error::ResultCode;
 
 /// Type of AES algorithm to use.
 #[doc(alias = "PS_AESAlgorithm")]

--- a/ctru-rs/src/services/romfs.rs
+++ b/ctru-rs/src/services/romfs.rs
@@ -28,7 +28,6 @@
 #![doc(alias = "filesystem")]
 
 use crate::error::ResultCode;
-use std::ffi::CStr;
 use std::sync::Mutex;
 
 use crate::services::ServiceReference;
@@ -65,13 +64,11 @@ impl RomFS {
         let _service_handler = ServiceReference::new(
             &ROMFS_ACTIVE,
             || {
-                let mount_name = CStr::from_bytes_with_nul(b"romfs\0").unwrap();
-                ResultCode(unsafe { ctru_sys::romfsMountSelf(mount_name.as_ptr()) })?;
+                ResultCode(unsafe { ctru_sys::romfsMountSelf(c"romfs".as_ptr()) })?;
                 Ok(())
             },
             || {
-                let mount_name = CStr::from_bytes_with_nul(b"romfs\0").unwrap();
-                let _ = unsafe { ctru_sys::romfsUnmount(mount_name.as_ptr()) };
+                let _ = unsafe { ctru_sys::romfsUnmount(c"romfs".as_ptr()) };
             },
         )?;
 

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -9,9 +9,9 @@ use libc::memalign;
 use std::net::Ipv4Addr;
 use std::sync::Mutex;
 
+use crate::Error;
 use crate::error::ResultCode;
 use crate::services::ServiceReference;
-use crate::Error;
 
 /// Handle to the Network Socket service.
 pub struct Soc {


### PR DESCRIPTION
Also bump CI to a more recent nightly and make use of `&raw const/mut` instead of the `addr_of` macros.

I don't remember if edition updates also mean we should update the crate version number. I could do that too if so.