### PR TITLE
Move custom panic hook function to the crate root

### DIFF
--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -94,18 +94,7 @@ impl PopUp {
     }
 }
 
-/// Sets a custom [panic hook](https://doc.rust-lang.org/std/panic/fn.set_hook.html) that uses the error applet to display panic messages.
-///
-/// You can also choose to have the previously registered panic hook called along with the error applet popup, which can be useful
-/// if you want to use output redirection to display panic messages over `3dslink` or `GDB`.
-///
-/// You can use [`std::panic::take_hook`](https://doc.rust-lang.org/std/panic/fn.take_hook.html) to unregister the panic hook
-/// set by this function.
-///
-/// # Notes
-///
-/// * If the [`Gfx`] service is not initialized during a panic, the error applet will not be displayed and the old panic hook will be called.
-pub fn set_panic_hook(call_old_hook: bool) {
+pub(crate) fn set_panic_hook(call_old_hook: bool) {
     use crate::services::gfx::GFX_ACTIVE;
     use std::sync::TryLockError;
 

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -69,3 +69,18 @@ mod sealed;
 pub mod services;
 
 pub use crate::error::{Error, Result};
+
+/// Sets a custom [panic hook](https://doc.rust-lang.org/std/panic/fn.set_hook.html) that uses the error applet to display panic messages.
+///
+/// You can also choose to have the previously registered panic hook called along with the error applet popup, which can be useful
+/// if you want to use output redirection to display panic messages over `3dslink` or `GDB`.
+///
+/// You can use [`std::panic::take_hook`](https://doc.rust-lang.org/std/panic/fn.take_hook.html) to unregister the panic hook
+/// set by this function.
+///
+/// # Notes
+///
+/// * If the [`Gfx`] service is not initialized during a panic, the error applet will not be displayed and the old panic hook will be called.
+pub fn set_panic_hook(call_old_hook: bool) {
+    crate::applets::error::set_panic_hook(call_old_hook);
+}


### PR DESCRIPTION
Setting the ctru panic hook can be pretty useful even if you don't intend to do anything else with the error applet, and I suspect that most users don't realize that this function exists at all. So I figured we might as well move the function to a more conspicuous location.