### PR TITLE
Make some new libctru types opaque

### DIFF
--- a/ctru-sys/build.rs
+++ b/ctru-sys/build.rs
@@ -139,6 +139,11 @@ fn main() {
         .blocklist_type("(in_addr|wchar|socklen|suseconds|sa_family|time)_t")
         .blocklist_item("SOL_CONFIG")
         .opaque_type("MiiData")
+        .opaque_type("FriendInfo")
+        .opaque_type("DecryptedApproachContext")
+        .opaque_type("CFLStoreData")
+        .opaque_type("AccountInfo")
+        .opaque_type("ExistentServerAccountData")
         .derive_default(true)
         .wrap_static_fns(true)
         .wrap_static_fns_path(out_dir.join("libctru_statics_wrapper"))
@@ -281,6 +286,11 @@ fn generate_layout_tests(
     test_generator
             // Opaque types:
             .blocklist_type("MiiData")
+            .blocklist_type("FriendInfo")
+            .blocklist_type("DecryptedApproachContext")
+            .blocklist_type("CFLStoreData")
+            .blocklist_type("AccountInfo")
+            .blocklist_type("ExistentServerAccountData")
             // Bitfields:
             .blocklist_field(
                 "ExHeader_SystemInfoFlags",


### PR DESCRIPTION
A [new version of libctru](https://github.com/devkitPro/libctru/releases/tag/v2.5.0) was released a few days ago and it added some structs that `bindgen` ends up choking on. It turns out that Rust doesn't allow `#[repr(packed)]` structs to transitively contain `#[repr(align)]` structs due to differing behavior between gcc and msvc toolchains. There is [an RFC in the works](https://github.com/rust-lang/rfcs/pull/3718) to find a long-term solution to this issue, but in the meantime we can work around the problem by just treating the problematic types as opaque blobs of bytes.