### PR TITLE
Edition bump and update to dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           args: --doc --workspace
 
       - name: Upload citra logs and capture videos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure() # always run unless the workflow was cancelled
         with:
           name: citra-logs-${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           # Run against a "known good" nightly. Rustc version is 1 day behind the toolchain date
-          - nightly-2025-03-30
+          - nightly-2025-07-25
           # Check for breakage on latest nightly
           - nightly
 
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - nightly-2025-03-30
+          - nightly-2025-07-25
           - nightly
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: rust3ds/test-runner/setup@v1
         with:
-          toolchain: nightly-2024-02-18
+          toolchain: nightly-2025-07-25
 
       - name: Build workspace docs
         run: cargo 3ds --verbose doc --verbose --no-deps --workspace
@@ -59,4 +59,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -32,7 +32,7 @@ toml = "0.9.4"
 [dev-dependencies]
 bytemuck = "1.12.3"
 cfg-if = "1.0.0"
-ferris-says = "0.3.2"
+ferris-says = "0.2.1"
 futures = "0.3"
 lewton = "0.10.2"
 test-runner = { git = "https://github.com/rust3ds/ctru-rs.git" }

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["os", "api-bindings", "hardware-support"]
 exclude = ["examples"]
 license = "Zlib"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lib]
 crate-type = ["rlib"]
@@ -27,12 +27,12 @@ macaddr = "1.0.1"
 widestring = "1.1.0"
 
 [build-dependencies]
-toml = "0.5"
+toml = "0.9.4"
 
 [dev-dependencies]
 bytemuck = "1.12.3"
 cfg-if = "1.0.0"
-ferris-says = "0.2.1"
+ferris-says = "0.3.2"
 futures = "0.3"
 lewton = "0.10.2"
 test-runner = { git = "https://github.com/rust3ds/ctru-rs.git" }

--- a/ctru-rs/examples/file-explorer.rs
+++ b/ctru-rs/examples/file-explorer.rs
@@ -119,7 +119,7 @@ impl<'a> FileExplorer<'a> {
                     println!("{i:2} - {}", entry.file_name().to_string_lossy());
                     self.entries.push(entry);
 
-                    if (i + 1) % 20 == 0 {
+                    if (i + 1).is_multiple_of(20) {
                         self.wait_for_page_down();
                     }
                 }

--- a/ctru-rs/examples/hello-world.rs
+++ b/ctru-rs/examples/hello-world.rs
@@ -16,7 +16,7 @@ fn main() {
     let _console = Console::new(gfx.top_screen.borrow_mut());
 
     // Snazzy message created via `ferris_says`.
-    let out = "Hello fellow Rustaceans, I'm on the Nintendo 3DS!";
+    let out = b"Hello fellow Rustaceans, I'm on the Nintendo 3DS!";
     let width = 24;
 
     let mut writer = BufWriter::new(Vec::new());

--- a/ctru-rs/examples/hello-world.rs
+++ b/ctru-rs/examples/hello-world.rs
@@ -16,7 +16,7 @@ fn main() {
     let _console = Console::new(gfx.top_screen.borrow_mut());
 
     // Snazzy message created via `ferris_says`.
-    let out = b"Hello fellow Rustaceans, I'm on the Nintendo 3DS!";
+    let out = "Hello fellow Rustaceans, I'm on the Nintendo 3DS!";
     let width = 24;
 
     let mut writer = BufWriter::new(Vec::new());

--- a/ctru-rs/examples/ir-user-circle-pad-pro.rs
+++ b/ctru-rs/examples/ir-user-circle-pad-pro.rs
@@ -147,10 +147,9 @@ impl<'screen> CirclePadProDemo<'screen> {
             if let Err(e) = self
                 .connection_status_event
                 .wait_for_event(Duration::from_millis(100))
+                && !e.is_timeout()
             {
-                if !e.is_timeout() {
-                    panic!("Couldn't initialize circle pad pro connection: {e}");
-                }
+                panic!("Couldn't initialize circle pad pro connection: {e}");
             }
 
             self.print_status_info();
@@ -168,10 +167,9 @@ impl<'screen> CirclePadProDemo<'screen> {
             if let Err(e) = self
                 .connection_status_event
                 .wait_for_event(Duration::from_millis(100))
+                && !e.is_timeout()
             {
-                if !e.is_timeout() {
-                    panic!("Couldn't initialize circle pad pro connection: {e}");
-                }
+                panic!("Couldn't initialize circle pad pro connection: {e}");
             }
         }
 
@@ -225,7 +223,7 @@ impl<'screen> CirclePadProDemo<'screen> {
         // Write data to top screen
         self.top_console.select();
         self.top_console.clear();
-        println!("{:x?}", status_info);
+        println!("{status_info:x?}");
 
         self.ir_user.process_shared_memory(|ir_mem| {
             println!("\nReceiveBufferInfo:");

--- a/ctru-rs/examples/local-networking.rs
+++ b/ctru-rs/examples/local-networking.rs
@@ -156,7 +156,7 @@ fn main() -> Result<(), Error> {
             }
             State::Connect => {
                 let appdata = uds.network_appdata(&networks[selected_network], None)?;
-                println!("App data: {:02X?}", appdata);
+                println!("App data: {appdata:02X?}");
 
                 if let Err(e) = uds.connect_network(
                     &networks[selected_network],
@@ -170,10 +170,10 @@ fn main() -> Result<(), Error> {
                     println!("Press A to start scanning or B to create a new network");
                 } else {
                     channel = uds.channel()?;
-                    println!("Connected using channel {}", channel);
+                    println!("Connected using channel {channel}");
 
                     let appdata = uds.appdata(None)?;
-                    println!("App data: {:02X?}", appdata);
+                    println!("App data: {appdata:02X?}");
 
                     if uds.wait_status_event(false, false)? {
                         prev_node_mask = handle_status_event(&uds, prev_node_mask)?;

--- a/ctru-rs/examples/title-info.rs
+++ b/ctru-rs/examples/title-info.rs
@@ -97,11 +97,11 @@ fn main() {
             if use_nand {
                 println!("Press SELECT to choose SD Card");
                 println!("Current medium: NAND");
-                println!("Title count: {}", nand_count);
+                println!("Title count: {nand_count}");
             } else {
                 println!("Press SELECT to choose NAND");
                 println!("Current medium: SD Card");
-                println!("Title count: {}", sd_count);
+                println!("Title count: {sd_count}");
             }
 
             refresh = false;

--- a/ctru-rs/src/services/am.rs
+++ b/ctru-rs/src/services/am.rs
@@ -140,7 +140,7 @@ impl Am {
     /// # }
     /// ```
     #[doc(alias = "AM_GetTitleList")]
-    pub fn title_list(&self, mediatype: MediaType) -> crate::Result<Vec<Title>> {
+    pub fn title_list(&self, mediatype: MediaType) -> crate::Result<Vec<Title<'_>>> {
         let count = self.title_count(mediatype)?;
         let mut buf = vec![0; count as usize];
         let mut read_amount = 0;

--- a/ctru-rs/src/services/gfx.rs
+++ b/ctru-rs/src/services/gfx.rs
@@ -37,7 +37,7 @@ pub trait Screen: Sealed {
     ///
     /// If the [`Gfx`] service was initialised via [`Gfx::with_formats_vram()`] this function will crash the program with an ARM exception.
     #[doc(alias = "gfxGetFramebuffer")]
-    fn raw_framebuffer(&mut self) -> RawFrameBuffer {
+    fn raw_framebuffer(&mut self) -> RawFrameBuffer<'_> {
         let mut width: u16 = 0;
         let mut height: u16 = 0;
         let ptr = unsafe {
@@ -408,12 +408,12 @@ impl Gfx {
 
 impl TopScreen3D<'_> {
     /// Immutably borrow the two sides of the screen as `(left, right)`.
-    pub fn split(&self) -> (Ref<TopScreenLeft>, Ref<TopScreenRight>) {
+    pub fn split(&self) -> (Ref<'_, TopScreenLeft>, Ref<'_, TopScreenRight>) {
         Ref::map_split(self.screen.borrow(), |screen| (&screen.left, &screen.right))
     }
 
     /// Mutably borrow the two sides of the screen as `(left, right)`.
-    pub fn split_mut(&self) -> (RefMut<TopScreenLeft>, RefMut<TopScreenRight>) {
+    pub fn split_mut(&self) -> (RefMut<'_, TopScreenLeft>, RefMut<'_, TopScreenRight>) {
         RefMut::map_split(self.screen.borrow_mut(), |screen| {
             (&mut screen.left, &mut screen.right)
         })

--- a/ctru-rs/src/services/ir_user.rs
+++ b/ctru-rs/src/services/ir_user.rs
@@ -357,7 +357,7 @@ impl IrUser {
 
 // Internal helper for rounding up a value to a multiple of another value.
 fn round_up(value: usize, multiple: usize) -> usize {
-    if value % multiple != 0 {
+    if !value.is_multiple_of(multiple) {
         (value / multiple) * multiple + multiple
     } else {
         (value / multiple) * multiple

--- a/ctru-rs/src/services/ndsp/mod.rs
+++ b/ctru-rs/src/services/ndsp/mod.rs
@@ -190,7 +190,7 @@ impl Ndsp {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn channel(&self, id: u8) -> std::result::Result<Channel, Error> {
+    pub fn channel(&self, id: u8) -> std::result::Result<Channel<'_>, Error> {
         let in_bounds = self.channel_flags.get(id as usize);
 
         match in_bounds {

--- a/ctru-rs/src/services/svc.rs
+++ b/ctru-rs/src/services/svc.rs
@@ -33,8 +33,7 @@ impl HandleExt for Handle {
     fn wait_for_event(self, timeout: Duration) -> crate::Result<()> {
         let timeout = i64::try_from(timeout.as_nanos()).map_err(|e| {
             crate::Error::Other(format!(
-                "Failed to convert timeout to 64-bit nanoseconds: {}",
-                e
+                "Failed to convert timeout to 64-bit nanoseconds: {e}"
             ))
         })?;
         unsafe {

--- a/ctru-rs/src/services/uds.rs
+++ b/ctru-rs/src/services/uds.rs
@@ -466,11 +466,12 @@ impl Uds {
     /// ```
     #[doc(alias = "udsInit")]
     pub fn new(username: Option<&str>) -> Result<Self, Error> {
-        if let Some(n) = username {
-            if n.len() > 10 {
-                return Err(Error::UsernameTooLong);
-            }
+        if let Some(n) = username
+            && n.len() > 10
+        {
+            return Err(Error::UsernameTooLong);
         }
+
         let cstr = username.map(CString::new).transpose()?;
         let handler = ServiceReference::new(
             &UDS_ACTIVE,
@@ -535,7 +536,7 @@ impl Uds {
                 additional_id.unwrap_or(0),
                 whitelist_macaddr
                     .map(|m| m.as_bytes().as_ptr())
-                    .unwrap_or(null()),
+                    .unwrap_or_default(),
                 self.service_status() == ServiceStatus::Client,
             )
         })?;

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["os", "external-ffi-bindings", "no-std", "hardware-support"]
 exclude = ["src/.gitattributes"]
 license = "Zlib"
 links = "ctru"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = []
@@ -33,17 +33,19 @@ required-features = ["layout-tests"]
 libc = { workspace = true }
 
 [build-dependencies]
-bindgen = { version = "0.69", features = ["experimental"] }
+bindgen = { version = "0.72", features = ["experimental"] }
 cc = "1.0"
 # Use git dependency so we can use https://github.com/mystor/rust-cpp/pull/111
 cpp_build = { optional = true, git = "https://github.com/mystor/rust-cpp.git" }
 doxygen-rs = "0.4.2"
-itertools = "0.11.0"
+itertools = "0.14.0"
 proc-macro2 = { version = "1.0.81", optional = true }
 quote = { version = "1.0.36", optional = true }
 regex = { version = "1.10.4", optional = true }
-rust-format = { version = "0.3.4", optional = true, features = ["token_stream"] }
-which = "4.4.0"
+rust-format = { version = "0.3.4", optional = true, features = [
+    "token_stream",
+] }
+which = "8.0.0"
 
 [dev-dependencies]
 shim-3ds = { workspace = true }

--- a/ctru-sys/build.rs
+++ b/ctru-sys/build.rs
@@ -310,6 +310,8 @@ fn generate_layout_tests(
             )
             // Variable-length arrays:
             .blocklist_field("romfs_(dir|file)", "name")
+            .blocklist_field("EulaEntry", "textData")
+            .blocklist_field("EulaList", "entries")
             // Bindgen anonymous types (and their associated fields):
             .blocklist_type(".*__bindgen.*")
             .blocklist_field(".*", "__bindgen.*")

--- a/ctru-sys/build.rs
+++ b/ctru-sys/build.rs
@@ -119,7 +119,7 @@ fn main() {
     let binding_builder = Builder::default()
         .header(ctru_header.to_str().unwrap())
         .header(errno_header.to_str().unwrap())
-        .rust_target(RustTarget::Nightly)
+        .rust_target(RustTarget::nightly())
         .use_core()
         .trust_clang_mangling(false)
         .must_use_type("Result")
@@ -138,15 +138,11 @@ fn main() {
         .blocklist_type("sockaddr_storage")
         .blocklist_type("(in_addr|wchar|socklen|suseconds|sa_family|time)_t")
         .blocklist_item("SOL_CONFIG")
-        .opaque_type("MiiData")
-        .opaque_type("FriendInfo")
-        .opaque_type("DecryptedApproachContext")
-        .opaque_type("CFLStoreData")
-        .opaque_type("AccountInfo")
-        .opaque_type("ExistentServerAccountData")
+        //.opaque_type("MiiData") Looks like MiiData can be built by the latest bindgen
         .derive_default(true)
         .wrap_static_fns(true)
         .wrap_static_fns_path(out_dir.join("libctru_statics_wrapper"))
+        .wrap_unsafe_ops(true)
         .clang_args(clang.args().iter().map(|s| s.to_str().unwrap()))
         .parse_callbacks(Box::new(CustomCallbacks));
 

--- a/ctru-sys/build/test_gen.rs
+++ b/ctru-sys/build/test_gen.rs
@@ -11,12 +11,12 @@ use std::io::Write;
 use std::path::Path;
 use std::rc::Rc;
 
+use bindgen::FieldVisibilityKind;
 use bindgen::callbacks::{
     DeriveInfo, DeriveTrait, FieldInfo, ImplementsTrait, ParseCallbacks, TypeKind,
 };
-use bindgen::FieldVisibilityKind;
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote, TokenStreamExt};
+use quote::{TokenStreamExt, format_ident, quote};
 use regex::Regex;
 use rust_format::{Formatter, RustFmt};
 

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![expect(unnecessary_transmutes)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -40,5 +41,5 @@ pub use bindings::*;
 /// In lieu of a proper errno function exposed by libc
 /// (<https://github.com/rust-lang/libc/issues/1995>).
 pub unsafe fn errno() -> s32 {
-    *__errno()
+    return unsafe { *__errno() };
 }

--- a/ctru-sys/tests/layout_test.rs
+++ b/ctru-sys/tests/layout_test.rs
@@ -18,9 +18,7 @@ fn size_of_ret<T, U>(_f: impl Fn(U) -> T) -> usize {
 }
 
 macro_rules! size_of {
-    ($ty:ident::$field:ident) => {{
-        $crate::size_of_ret(|x: $ty| x.$field)
-    }};
+    ($ty:ident::$field:ident) => {{ $crate::size_of_ret(|x: $ty| x.$field) }};
     ($ty:ty) => {
         ::std::mem::size_of::<$ty>()
     };


### PR DESCRIPTION
# Changes
Edition bump to 2024, MSRV upped to 1.88 and update to most dependencies.
Especially `bindgen`, which can now generate `MiiData`, so that it won't need to be `opaque` anymore. I also implemented the `From<ctru_sys::MiiData>` trait using the basic `bindgen` functions rather than our original manual implementations.

There have been some minor clippy lints and formatting changes as well.

# Problems ~~(as always)~~
@ian-h-chamberlain The new version of `ferris-says` uses the `regex` crate (great dependency bloat :partying_face:), and this causes a not-so peculiar stack overflow in the `hello-world` example *only* when running in `debug` mode, as should-have-been-fixed in #59. 
This is because the `__stacksize__` symbol is not properly set to 2MB, even though the `big-stack` feature is enabled. This is very much due to the fact that `ctru-rs` is linked before `libctru`, causing the same old link priority issue we have had for the entirety of this toolchain's life.

It's easy to check the symbol's value by doing:
```bash
arm-none-eabi-objdump -t "target/armv6k-nintendo-3ds/debug/examples/hello-world.elf" | grep 'stacksize'
```
and then searching in the binary the symbol's value at the specified section/address. Its value is usually either:
- 0x00800000, 32KB in little endian
- 0x00002000, 2MB in little endian 

The issue can be resolved by inserting the definition directly in the example (since the binary is linked last):
```Rust
#[unsafe(no_mangle)]
static __stacksize__: usize = 2 * 1024 * 1024;
```

How do you think this should be fixed? I'm perfectly fine with yanking `ferris-says` to make the example work, but I didn't know this issue affected the examples, and am worried maybe our patch didn't actually work that well. Maybe we should resort to the "macro implementation" as originally proposed in #59?