### PR TITLE
Remove allocations from the ctru panic hook

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -25,7 +25,6 @@ libc = { workspace = true, default-features = true }
 bitflags = "2.6.0"
 macaddr = "1.0.1"
 widestring = "1.1.0"
-itoa = "1.0.15"
 
 [build-dependencies]
 toml = "0.9.4"

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -25,6 +25,7 @@ libc = { workspace = true, default-features = true }
 bitflags = "2.6.0"
 macaddr = "1.0.1"
 widestring = "1.1.0"
+itoa = "1.0.15"
 
 [build-dependencies]
 toml = "0.9.4"

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -101,8 +101,10 @@ struct ErrorConfWriter<'a> {
 
 impl std::fmt::Write for ErrorConfWriter<'_> {
     fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
+        let max = self.error_conf.Text.len() - 1;
+
         for code_unit in s.encode_utf16() {
-            if self.index == self.error_conf.Text.len() - 1 {
+            if self.index == max {
                 self.error_conf.Text[self.index] = 0;
                 return Err(std::fmt::Error);
             } else {
@@ -110,6 +112,8 @@ impl std::fmt::Write for ErrorConfWriter<'_> {
                 self.index += 1;
             }
         }
+
+        self.error_conf.Text[self.index] = 0;
 
         Ok(())
     }
@@ -149,7 +153,7 @@ pub(crate) fn set_panic_hook(call_old_hook: bool) {
 
             let name = thread.name().unwrap_or("<unnamed>");
 
-            let _ = write!(writer, "thread '{name}' {panic_info}\0");
+            let _ = write!(writer, "thread '{name}' {panic_info}");
 
             unsafe {
                 errorDisp(error_conf);

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -128,7 +128,7 @@ pub(crate) fn set_panic_hook(call_old_hook: bool) {
 
     let mut lock = ERROR_CONF.lock().unwrap();
 
-    unsafe { errorInit(&raw mut *lock, WordWrap::Enabled as _, 0) };
+    unsafe { errorInit(&mut *lock, WordWrap::Enabled as _, 0) };
 
     let old_hook = std::panic::take_hook();
 
@@ -142,7 +142,7 @@ pub(crate) fn set_panic_hook(call_old_hook: bool) {
 
             let mut lock = ERROR_CONF.lock().unwrap();
 
-            let error_conf = unsafe { (&raw mut *lock).as_mut().unwrap() };
+            let error_conf = &mut *lock;
 
             let mut writer = ErrorConfWriter {
                 error_conf,

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -107,6 +107,8 @@ impl PanicHookConfig {
         }
     }
 
+    // There can only be one invocation of an applet active at any given time, so our `UnsafeCell`
+    // crimes *should* be okay here.
     unsafe fn get(&self) -> *mut errorConf {
         unsafe { (*self.error_app.get()).state.as_mut() }
     }


### PR DESCRIPTION
This PR changes the panic hook so that it creates the error app config ahead of time and then performs no further allocations upon invocation. Or at least no extra allocations on the `ctru-rs` side of things; no idea if there are extra allocations that happen when calling the applet or unwinding the stack, but we don't have control over those things anyway.