### PR TITLE
Add helper type for writing to UTF-16 buffers

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -24,7 +24,6 @@ pthread-3ds = { workspace = true }
 libc = { workspace = true, default-features = true }
 bitflags = "2.6.0"
 macaddr = "1.0.1"
-widestring = "1.1.0"
 
 [build-dependencies]
 toml = "0.9.4"

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -2,9 +2,12 @@
 //!
 //! This applet displays error text as a pop-up message on the lower screen.
 
+use crate::Utf16Writer;
 use crate::services::{apt::Apt, gfx::Gfx};
 
 use ctru_sys::{errorConf, errorDisp, errorInit};
+
+use std::fmt::Write;
 
 /// Configuration struct to set up the Error applet.
 #[doc(alias = "errorConf")]
@@ -59,14 +62,9 @@ impl PopUp {
     /// 1900 UTF-16 code units in length after conversion.
     #[doc(alias = "errorText")]
     pub fn set_text(&mut self, text: &str) {
-        for (idx, code_unit) in text
-            .encode_utf16()
-            .take(self.state.Text.len() - 1)
-            .chain(std::iter::once(0))
-            .enumerate()
-        {
-            self.state.Text[idx] = code_unit;
-        }
+        let mut writer = Utf16Writer::new(&mut self.state.Text);
+
+        let _ = writer.write_str(text);
     }
 
     /// Launches the error applet.

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -92,31 +92,6 @@ impl PopUp {
     }
 }
 
-struct ErrorConfWriter<'a> {
-    error_conf: &'a mut errorConf,
-    index: usize,
-}
-
-impl std::fmt::Write for ErrorConfWriter<'_> {
-    fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
-        let max = self.error_conf.Text.len() - 1;
-
-        for code_unit in s.encode_utf16() {
-            if self.index == max {
-                self.error_conf.Text[self.index] = 0;
-                return Err(std::fmt::Error);
-            } else {
-                self.error_conf.Text[self.index] = code_unit;
-                self.index += 1;
-            }
-        }
-
-        self.error_conf.Text[self.index] = 0;
-
-        Ok(())
-    }
-}
-
 pub(crate) fn set_panic_hook(call_old_hook: bool) {
     use crate::services::gfx::GFX_ACTIVE;
     use std::fmt::Write;
@@ -142,10 +117,7 @@ pub(crate) fn set_panic_hook(call_old_hook: bool) {
 
             let error_conf = &mut *lock;
 
-            let mut writer = ErrorConfWriter {
-                error_conf,
-                index: 0,
-            };
+            let mut writer = Utf16Writer::new(&mut error_conf.Text);
 
             let thread = std::thread::current();
 

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -56,7 +56,7 @@ impl PopUp {
     ///
     /// # Notes
     ///
-    /// The input string be converted to UTF-16 for display with the applet, and the message will be
+    /// The input will be converted to UTF-16 for display with the applet, and the message will be
     /// truncated if it exceeds 1900 UTF-16 code units in length after conversion.
     ///
     /// # Example

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -74,7 +74,7 @@ impl PopUp {
     /// # }
     /// ```
     #[doc(alias = "errorText")]
-    pub fn writer<'a>(&'a mut self) -> Utf16Writer<'a> {
+    pub fn writer(&mut self) -> Utf16Writer<'_> {
         Utf16Writer::new(&mut self.state.Text)
     }
 

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -7,8 +7,6 @@ use crate::services::{apt::Apt, gfx::Gfx};
 
 use ctru_sys::{errorConf, errorDisp, errorInit};
 
-use std::fmt::Write;
-
 /// Configuration struct to set up the Error applet.
 #[doc(alias = "errorConf")]
 pub struct PopUp {
@@ -54,17 +52,30 @@ impl PopUp {
         Self { state }
     }
 
-    /// Sets the error text to display.
+    /// Returns a [`Utf16Writer`] that writes its output to the [`PopUp`]'s internal text buffer.
     ///
     /// # Notes
     ///
-    /// The text will be converted to UTF-16 for display with the applet, and the message will be truncated if it exceeds
-    /// 1900 UTF-16 code units in length after conversion.
+    /// The input string be converted to UTF-16 for display with the applet, and the message will be
+    /// truncated if it exceeds 1900 UTF-16 code units in length after conversion.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # fn main() {
+    /// #
+    /// use std::fmt::Write;
+    ///
+    /// let mut popup = PopUp::new(WordWrap::Enabled);
+    ///
+    /// let _ = write!(popup.writer(), "Look mom, I'm a custom error message!");
+    /// #
+    /// # }
+    /// ```
     #[doc(alias = "errorText")]
-    pub fn set_text(&mut self, text: &str) {
-        let mut writer = Utf16Writer::new(&mut self.state.Text);
-
-        let _ = writer.write_str(text);
+    pub fn writer<'a>(&'a mut self) -> Utf16Writer<'a> {
+        Utf16Writer::new(&mut self.state.Text)
     }
 
     /// Launches the error applet.

--- a/ctru-rs/src/applets/error.rs
+++ b/ctru-rs/src/applets/error.rs
@@ -65,6 +65,7 @@ impl PopUp {
     /// # let _runner = test_runner::GdbRunner::default();
     /// # fn main() {
     /// #
+    /// use ctru::applets::error::{PopUp, WordWrap};
     /// use std::fmt::Write;
     ///
     /// let mut popup = PopUp::new(WordWrap::Enabled);

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -772,13 +772,13 @@ impl SoftwareKeyboard {
 
         if swkbd.text_length > 0 {
             let text16 = unsafe {
-                widestring::Utf16Str::from_slice_unchecked(std::slice::from_raw_parts(
+                std::slice::from_raw_parts(
                     swkbd_shared_mem_ptr.add(swkbd.text_offset as _).cast(),
                     swkbd.text_length as _,
-                ))
+                )
             };
 
-            *output = text16.to_string();
+            *output = String::from_utf16(text16).unwrap();
         }
 
         if swkbd.save_state_flags & (1 << 0) != 0 {
@@ -825,13 +825,13 @@ impl SoftwareKeyboard {
         let data = unsafe { &*user.cast::<MessageCallbackData>() };
 
         let text16 = unsafe {
-            widestring::Utf16Str::from_slice_unchecked(std::slice::from_raw_parts(
+            std::slice::from_raw_parts(
                 data.swkbd_shared_mem_ptr.add(swkbd.text_offset as _).cast(),
                 swkbd.text_length as _,
-            ))
+            )
         };
 
-        let text8 = text16.to_string();
+        let text8 = String::from_utf16(text16).unwrap();
 
         let result = unsafe { &mut **data.filter_callback }(&text8);
 

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -89,6 +89,14 @@ pub fn set_panic_hook(call_old_hook: bool) {
 ///
 /// This type is mainly useful for interop with `libctru` APIs that expect UTF-16 text as input. The writer implements the
 /// [`std::fmt::Write`](https://doc.rust-lang.org/std/fmt/trait.Write.html) trait and ensures that the text is written in-bounds and properly nul-terminated.
+///
+/// # Notes
+///
+/// Subsequent writes to the same `Utf16Writer` will append to the buffer instead of overwriting the existing contents. If you want to start over from the
+/// beginning of the buffer, simply create a new `Utf16Writer`.
+///
+/// If a write causes the buffer to reach the end of its capacity, `std::fmt::Error` will be returned, but all string data up until the end of the capacity will
+/// still be written.
 pub struct Utf16Writer<'a> {
     buf: &'a mut [u16],
     index: usize,

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -94,10 +94,10 @@ pub struct Utf16Writer<'a> {
     index: usize,
 }
 
-impl<'a> Utf16Writer<'a> {
+impl Utf16Writer<'_> {
     /// Creates a new [Utf16Writer] that writes its output into the provided buffer.
-    pub fn new(buf: &'a mut [u16]) -> Self {
-        Self { buf, index: 0 }
+    pub fn new(buf: &mut [u16]) -> Utf16Writer<'_> {
+        Utf16Writer { buf, index: 0 }
     }
 }
 

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -85,9 +85,10 @@ pub fn set_panic_hook(call_old_hook: bool) {
     crate::applets::error::set_panic_hook(call_old_hook);
 }
 
-/// A helper type for writing string data into UTF-16 text buffers. Useful for interoperating with `libctru` APIs that expect UTF-16 as input.
+/// A helper type for writing string data into `[u16]` buffers.
 ///
-/// The writer ensures that the text is written in-bounds and properly nul-terminated.
+/// This type is mainly useful for interop with `libctru` APIs that expect UTF-16 text as input. The writer implements the
+/// [`std::fmt::Write`](https://doc.rust-lang.org/std/fmt/trait.Write.html) trait and ensures that the text is written in-bounds and properly nul-terminated.
 pub struct Utf16Writer<'a> {
     buf: &'a mut [u16],
     index: usize,


### PR DESCRIPTION
This PR takes the new UTF-16 handling code from https://github.com/rust3ds/ctru-rs/pull/231 and applies it everywhere in `ctru-rs` as well as exposing a new public API. It even handles nul-termination properly this time, so that's neat too!

https://github.com/rust3ds/ctru-rs/pull/231 should probably be merged before this one, after which I can rebase and remove the redundant `ErrorConfWriter` code.