### PR TITLE
fix: use the new upstream interface for creating a TestList

### DIFF
--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -20,7 +20,7 @@ use std::process::{ExitCode, Termination};
 pub use console::ConsoleRunner;
 pub use gdb::GdbRunner;
 pub use socket::SocketRunner;
-use test::{ColorConfig, OutputFormat, TestDescAndFn, TestFn, TestOpts};
+use test::{ColorConfig, OutputFormat, TestDescAndFn, TestFn, TestList, TestListOrder, TestOpts};
 
 /// Run tests using the [`GdbRunner`].
 /// This function can be used with the `#[test_runner]` attribute.
@@ -60,7 +60,10 @@ fn run<Runner: TestRunner>(tests: &[&TestDescAndFn]) {
         ..test::test::parse_opts(&[]).unwrap().unwrap()
     };
 
-    let tests = tests.iter().map(|t| make_owned_test(t)).collect();
+    let tests = TestList::new(
+        tests.iter().map(make_owned_test).collect(),
+        TestListOrder::Unsorted,
+    );
     let result = test::run_tests_console(&opts, tests);
 
     drop(ctx);


### PR DESCRIPTION
Upstream [added support for binary search over a TestList](https://github.com/rust-lang/rust/commit/bbb9e3bb4a40f82e39a0d30b34fcaa5f8c2d1c6c), which involved creating a new TestList struct which indicates whether or not the tests are sorted by name.